### PR TITLE
fix: resolve numbers starting with zero as string

### DIFF
--- a/lib/services/voiceflow/utils.ts
+++ b/lib/services/voiceflow/utils.ts
@@ -32,8 +32,9 @@ export const sanitizeVariables = (variables: Record<string, any>) =>
   }, {});
 
 const _stringToNumIfNumeric = (str: string | null): number | string | null => {
-  const number = Number(str);
+  if (str?.startsWith('0')) return str;
 
+  const number = Number(str);
   return Number.isNaN(number) ? str : number;
 };
 


### PR DESCRIPTION
So phone numbers in Europe can start with 0 and it is pretty important to preserve it. 

I think we can safely assume any number slot starting with a 0 should be a string, and in all other cases it is very easy in Javascript to use numbers as strings.