### PR TITLE
fix: resolve 0 as number

### DIFF
--- a/lib/services/voiceflow/utils.ts
+++ b/lib/services/voiceflow/utils.ts
@@ -32,7 +32,7 @@ export const sanitizeVariables = (variables: Record<string, any>) =>
   }, {});
 
 const _stringToNumIfNumeric = (str: string | null): number | string | null => {
-  if (str?.startsWith('0')) return str;
+  if (str?.startsWith('0') && str.length > 1) return str;
 
   const number = Number(str);
   return Number.isNaN(number) ? str : number;


### PR DESCRIPTION
yeah... if the number starts with 0 but also is 0, then please resolve it as a number instead of a string

i.e. `01` is a string, but `0` is a number