### PR TITLE
fix: bump client

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "dependencies": {
     "@types/pino": "^6.3.0",
     "@voiceflow/backend-utils": "2.1.0",
-    "@voiceflow/client": "^1.7.5",
+    "@voiceflow/client": "^1.7.7",
     "@voiceflow/common": "^6.2.0",
     "@voiceflow/logger": "^1.1.10",
     "@voiceflow/secrets-provider": "^1.6.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -915,10 +915,10 @@
     randomstring "^1.1.5"
     sinon "^7.5.0"
 
-"@voiceflow/client@^1.7.5":
-  version "1.7.5"
-  resolved "https://registry.yarnpkg.com/@voiceflow/client/-/client-1.7.5.tgz#5506aa723bc225f5edd08bbd5d063b72f9ec199d"
-  integrity sha512-y8i4BJYrELGDQ0OGP5Ce+L1noKd2f+D7AbMm0aMFJMDCLn6E68Qp8UunkkP/2AhWSwYniw49in7Z257EjaS5WA==
+"@voiceflow/client@^1.7.7":
+  version "1.7.7"
+  resolved "https://registry.yarnpkg.com/@voiceflow/client/-/client-1.7.7.tgz#e3c39b8223997acc5e553b637744b1d534703e4d"
+  integrity sha512-KeUVzvFxD5ejq4kow7Yqs54NPQ7/43hXoBYBHukQ7XveXCwK466113FjTjokE/0QG52JOixrvim2YIcgoRRO3w==
   dependencies:
     "@types/safe-json-stringify" "^1.1.0"
     axios "^0.19.0"


### PR DESCRIPTION
just to be safe I am not going to push this to production yet. Mostly looking at this:
https://github.com/voiceflow/client/commit/14769f83144a703136ec7faf21cd80adad766d41

It should be fine but this is required for data refactor testing