### PR TITLE
fix: null choices not handled

### DIFF
--- a/lib/services/voiceflow/handlers/interaction.ts
+++ b/lib/services/voiceflow/handlers/interaction.ts
@@ -38,7 +38,7 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
       return node.id;
     }
 
-    let nextId: string | null = null;
+    let nextId: string | null | undefined;
     let variableMap: SlotMapping[] | null = null;
 
     const { intent } = request.payload;
@@ -59,7 +59,7 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
     }
 
     // check if there is a command in the stack that fulfills intent
-    if (!nextId) {
+    if (nextId === undefined) {
       if (utils.commandHandler.canHandle(context)) {
         return utils.commandHandler.handle(context, variables);
       }
@@ -72,7 +72,7 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
     context.turn.delete(T.REQUEST);
 
     // check for noMatches to handle
-    if (!nextId && utils.noMatchHandler.canHandle(node, context)) {
+    if (nextId === undefined && utils.noMatchHandler.canHandle(node, context)) {
       return utils.noMatchHandler.handle(node, context, variables);
     }
 


### PR DESCRIPTION
this is a bit weird, but if a choice has no port, it technically leads out to `null` and should be considered handled.

The problem is that if you go down a `null` port it keeps trying to handle it through the `commandHandler` and `noMatchHandler` which leads to weird behavior.

now `null` or `undefined` is a big difference in falsy values for `nextId`

the other way to do this is default `nextId = null` and have a `handled: boolean` flag