### PR TITLE
fix: remove prototype related code

### DIFF
--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -52,6 +52,7 @@ const buildClients = (config: Config): ClientMap => {
 
 export const initClients = async (_config: Config, clients: ClientMap) => {
   await clients.dataAPI.init();
+  await clients.prototypeDataAPI.init();
   await clients.mongo?.start();
 };
 

--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -8,6 +8,7 @@ import Dynamo, { DynamoType } from './dynamo';
 import Metrics, { MetricsType } from './metrics';
 import MongoDB from './mongodb';
 import Multimodal, { MultimodalType } from './multimodal';
+import PrototypeServerDataApi from './prototypeServerDataApi';
 import Static, { StaticType } from './static';
 
 export interface ClientMap extends StaticType {
@@ -16,6 +17,7 @@ export interface ClientMap extends StaticType {
   dataAPI: DataAPI<AlexaProgram, AlexaVersion>;
   metrics: MetricsType;
   mongo: MongoDB | null;
+  prototypeDataAPI: PrototypeServerDataApi;
 }
 
 /**
@@ -25,10 +27,17 @@ const buildClients = (config: Config): ClientMap => {
   const dynamo = Dynamo(config);
   const dataAPI = config.PROJECT_SOURCE
     ? new LocalDataApi({ projectSource: config.PROJECT_SOURCE }, { fs: Static.fs, path: Static.path })
-    : new ServerDataApi({ adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT }, { axios: Static.axios });
+    : new ServerDataApi(
+        { platform: 'alexa', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT },
+        { axios: Static.axios }
+      );
   const multimodal = Multimodal(dataAPI);
   const metrics = Metrics(config);
   const mongo = MongoPersistenceAdapter.enabled(config) ? new MongoDB(config) : null;
+  const prototypeDataAPI = new PrototypeServerDataApi(
+    { platform: 'alexa', adminToken: config.ADMIN_SERVER_DATA_API_TOKEN, dataEndpoint: config.VF_DATA_ENDPOINT },
+    { axios: Static.axios }
+  );
 
   return {
     ...Static,
@@ -37,6 +46,7 @@ const buildClients = (config: Config): ClientMap => {
     dataAPI,
     metrics,
     mongo,
+    prototypeDataAPI,
   };
 };
 

--- a/lib/clients/prototypeServerDataApi.ts
+++ b/lib/clients/prototypeServerDataApi.ts
@@ -1,0 +1,13 @@
+import { AlexaCommands, AlexaNodes, AlexaVersionData } from '@voiceflow/alexa-types';
+import { Program, Version } from '@voiceflow/api-sdk';
+import { ServerDataApi } from '@voiceflow/runtime';
+
+class PrototypeServerDataApi extends ServerDataApi<Program<AlexaNodes, AlexaCommands>, Version<AlexaVersionData>> {
+  public getProgram = async (programID: string) => {
+    const { data } = await this.client.get<Program<AlexaNodes, AlexaCommands>>(`/test/diagrams/${programID}`);
+
+    return data;
+  };
+}
+
+export default PrototypeServerDataApi;

--- a/lib/services/test/index.ts
+++ b/lib/services/test/index.ts
@@ -21,12 +21,10 @@ const TestManager = (services: Services, config: Config, utils = utilsObj) => {
   const handlers = utils.Handlers(config);
 
   const invoke = async (state: State, request?: Request) => {
-    const { voiceflow, dataAPI } = services;
+    const { voiceflow, prototypeDataAPI } = services;
 
     const context = voiceflow.client.createContext(TEST_VERSION_ID, state as State, request, {
-      api: {
-        getProgram: dataAPI.getTestProgram,
-      } as any,
+      api: prototypeDataAPI,
       handlers,
     });
 

--- a/lib/services/voiceflow/handlers/command.ts
+++ b/lib/services/voiceflow/handlers/command.ts
@@ -1,5 +1,4 @@
-import { Command } from '@voiceflow/api-sdk';
-import { CommandMapping } from '@voiceflow/general-types';
+import { Command, CommandMapping } from '@voiceflow/api-sdk';
 import { Command as IntentCommand } from '@voiceflow/general-types/build/nodes/command';
 import { Context, extractFrameCommand, Frame, Store } from '@voiceflow/runtime';
 import _ from 'lodash';

--- a/lib/services/voiceflow/handlers/interaction.ts
+++ b/lib/services/voiceflow/handlers/interaction.ts
@@ -1,4 +1,5 @@
-import { SlotMapping, TraceType } from '@voiceflow/general-types';
+import { SlotMapping } from '@voiceflow/api-sdk';
+import { TraceType } from '@voiceflow/general-types';
 import { Node, TraceFrame } from '@voiceflow/general-types/build/nodes/interaction';
 import { formatIntentName, HandlerFactory } from '@voiceflow/runtime';
 

--- a/lib/services/voiceflow/utils.ts
+++ b/lib/services/voiceflow/utils.ts
@@ -1,4 +1,4 @@
-import { SlotMapping } from '@voiceflow/general-types';
+import { SlotMapping } from '@voiceflow/api-sdk';
 import { Context, formatIntentName, replaceVariables, Store, transformStringVariableToNumber } from '@voiceflow/runtime';
 import { Slot } from 'ask-sdk-model';
 import _ from 'lodash';

--- a/package.json
+++ b/package.json
@@ -12,11 +12,11 @@
     }
   },
   "dependencies": {
-    "@voiceflow/alexa-types": "1.30.3",
-    "@voiceflow/api-sdk": "^1.6.1",
+    "@voiceflow/alexa-types": "1.30.2",
+    "@voiceflow/api-sdk": "1.17.1",
     "@voiceflow/backend-utils": "^2.1.1",
     "@voiceflow/common": "^6.2.0",
-    "@voiceflow/general-types": "1.7.0",
+    "@voiceflow/general-types": "1.10.2",
     "@voiceflow/logger": "^1.4.0",
     "@voiceflow/runtime": "1.11.3",
     "@voiceflow/verror": "^1.1.0",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@voiceflow/common": "^6.2.0",
     "@voiceflow/general-types": "1.10.2",
     "@voiceflow/logger": "^1.4.0",
-    "@voiceflow/runtime": "1.11.3",
+    "@voiceflow/runtime": "1.12.0",
     "@voiceflow/verror": "^1.1.0",
     "alexa-verifier-middleware": "^1.0.2",
     "ask-sdk": "^2.9.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     }
   },
   "dependencies": {
-    "@voiceflow/alexa-types": "1.30.2",
+    "@voiceflow/alexa-types": "1.32.2",
     "@voiceflow/api-sdk": "1.17.1",
     "@voiceflow/backend-utils": "^2.1.1",
     "@voiceflow/common": "^6.2.0",

--- a/tests/lib/clients/index.unit.ts
+++ b/tests/lib/clients/index.unit.ts
@@ -10,19 +10,22 @@ describe('client unit tests', () => {
 
   describe('initClients', () => {
     it('mongo state disabled', async () => {
-      const clients = { dataAPI: { init: sinon.stub() } };
+      const clients = { dataAPI: { init: sinon.stub() }, prototypeDataAPI: { init: sinon.stub() } };
 
       await initClients({ SESSIONS_SOURCE: 'dynamo' } as any, clients as any);
 
       expect(clients.dataAPI.init.callCount).to.eql(1);
+      expect(clients.prototypeDataAPI.init.callCount).to.eql(1);
     });
 
     it('mongo state enabled', async () => {
-      const clients = { dataAPI: { init: sinon.stub() }, mongo: { start: sinon.stub() } };
+      const clients = { dataAPI: { init: sinon.stub() }, prototypeDataAPI: { init: sinon.stub() }, mongo: { start: sinon.stub() } };
 
       await initClients({ SESSIONS_SOURCE: 'mongo' } as any, clients as any);
 
       expect(clients.dataAPI.init.callCount).to.eql(1);
+      expect(clients.prototypeDataAPI.init.callCount).to.eql(1);
+
       expect(clients.mongo.start.callCount).to.eql(1);
     });
   });

--- a/tests/lib/services/test/index.unit.ts
+++ b/tests/lib/services/test/index.unit.ts
@@ -45,7 +45,7 @@ describe('test manager unit tests', () => {
 
       const services = {
         voiceflow: { client: { createContext } },
-        dataAPI: { getProgram: 'api' },
+        prototypeDataAPI: { getProgram: 'api' },
       };
       const utils = {
         Handlers: () => 'foo',
@@ -64,7 +64,7 @@ describe('test manager unit tests', () => {
           state,
           request,
           {
-            api: { getProgram: services.dataAPI.getProgram },
+            api: { getProgram: services.prototypeDataAPI.getProgram },
             handlers: 'foo',
           },
         ],
@@ -104,7 +104,7 @@ describe('test manager unit tests', () => {
 
       const services = {
         voiceflow: { client: { createContext } },
-        dataAPI: { getProgram: 'api' },
+        prototypeDataAPI: { getProgram: 'api' },
       };
       const utils = {
         Handlers: sinon.stub().returns([]),
@@ -146,7 +146,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getProgram: 'api' },
+          prototypeDataAPI: { getProgram: 'api' },
         };
 
         const config = {};
@@ -197,7 +197,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getProgram: 'api' },
+          prototypeDataAPI: { getProgram: 'api' },
         };
 
         const config = {};
@@ -248,7 +248,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getProgram: 'api' },
+          prototypeDataAPI: { getProgram: 'api' },
         };
 
         const config = {};

--- a/tests/lib/services/test/index.unit.ts
+++ b/tests/lib/services/test/index.unit.ts
@@ -45,7 +45,7 @@ describe('test manager unit tests', () => {
 
       const services = {
         voiceflow: { client: { createContext } },
-        dataAPI: { getTestProgram: 'api' },
+        dataAPI: { getProgram: 'api' },
       };
       const utils = {
         Handlers: () => 'foo',
@@ -64,7 +64,7 @@ describe('test manager unit tests', () => {
           state,
           request,
           {
-            api: { getProgram: services.dataAPI.getTestProgram },
+            api: { getProgram: services.dataAPI.getProgram },
             handlers: 'foo',
           },
         ],
@@ -104,7 +104,7 @@ describe('test manager unit tests', () => {
 
       const services = {
         voiceflow: { client: { createContext } },
-        dataAPI: { getTestProgram: 'api' },
+        dataAPI: { getProgram: 'api' },
       };
       const utils = {
         Handlers: sinon.stub().returns([]),
@@ -146,7 +146,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getTestProgram: 'api' },
+          dataAPI: { getProgram: 'api' },
         };
 
         const config = {};
@@ -197,7 +197,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getTestProgram: 'api' },
+          dataAPI: { getProgram: 'api' },
         };
 
         const config = {};
@@ -248,7 +248,7 @@ describe('test manager unit tests', () => {
 
         const services = {
           voiceflow: { client: { createContext } },
-          dataAPI: { getTestProgram: 'api' },
+          dataAPI: { getProgram: 'api' },
         };
 
         const config = {};

--- a/tests/smokeTest/smokeTestRunner.ts
+++ b/tests/smokeTest/smokeTestRunner.ts
@@ -159,6 +159,7 @@ const beforeAll = async () => {
   // mock server-data-api token gen
   nock(config.VF_DATA_ENDPOINT)
     .intercept('/generate-platform-token', 'POST')
+    .times(2) // TODO: remove after prototypeDataAPI deleted
     .reply(200, { token: 'token' });
 
   await server.start();

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,13 +997,13 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@voiceflow/alexa-types@1.30.3":
-  version "1.30.3"
-  resolved "https://registry.yarnpkg.com/@voiceflow/alexa-types/-/alexa-types-1.30.3.tgz#198f4e86d0780cfb0028441c8a4c6448c4e32ea6"
-  integrity sha512-VU2SwE4ilAB/Wxm38DJaesNR3vg8j7nojPmP6xZqq4f9MfZSpIVlmpBiyz+uFM9vxZViL1pchv1zyCtN6kSuOg==
+"@voiceflow/alexa-types@1.30.2":
+  version "1.30.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/alexa-types/-/alexa-types-1.30.2.tgz#6dd74c94f44599d2532962c560da5267b85030ab"
+  integrity sha512-8SjRZ6UsBLdnxlpsWUjrzLSMO5lsdSib+HctGLNjpZPNUy+RxtNb1CkZ9W4oA7WybkHQ6+oZ8G4XnuMEHXVInw==
   dependencies:
     "@voiceflow/api-sdk" "1.10.1"
-    "@voiceflow/general-types" "1.3.0"
+    "@voiceflow/general-types" "^1.2.0"
     ask-smapi-model "^1.11.0"
     eslint-plugin-prettier "^3.1.4"
 
@@ -1021,24 +1021,10 @@
     regenerator-runtime "^0.13.5"
     superstruct "^0.10.12"
 
-"@voiceflow/api-sdk@1.13.0":
-  version "1.13.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.13.0.tgz#cff763433fad24906347e6c88fd58e2af8d9cf33"
-  integrity sha512-uZVNdYy52lBCXPutTHPOynXi64b+P463fugEfm/A76nJK93gM9WYWNnBBiLkBlpC15CDeF7dTXNlfE32blBQNw==
-  dependencies:
-    "@types/atob" "^2.1.2"
-    "@voiceflow/logger" "^1.1.10"
-    atob "^2.1.2"
-    axios "^0.19.2"
-    core-js "^3.6.5"
-    io-ts "^2.2.8"
-    regenerator-runtime "^0.13.5"
-    superstruct "^0.10.12"
-
-"@voiceflow/api-sdk@^1.6.1":
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.8.0.tgz#9d1a810c3b9254ff43de8980f6be557db4bf6a53"
-  integrity sha512-Y95JnH2/rt77RRWk//ZtX0fRuWrmqIFHYOQ/rjUpsoEgJDka5roXntXWVnBiB4/C3gSzNynnHAFW04lVs4BYrw==
+"@voiceflow/api-sdk@1.17.1":
+  version "1.17.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.17.1.tgz#7843eec956ad8b4ad155fed17b4bbea1eb334360"
+  integrity sha512-0baZTNROfwYJoaAGphRePIAhMnr1C3P7yY/DYNd6THd0KvxI/3M623ZwLBfhaC49ioxE4Um7a5tXO++visR/Ng==
   dependencies:
     "@types/atob" "^2.1.2"
     "@voiceflow/logger" "^1.1.10"
@@ -1105,12 +1091,12 @@
     eslint-plugin-sonarjs "^0.4.0"
     eslint-plugin-xss "^0.1.9"
 
-"@voiceflow/general-types@1.3.0":
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.3.0.tgz#fea802ef2116add8b8f634ed544f293cc83293a3"
-  integrity sha512-rjrONcH0fZYFw9+Qe1eWfO7Lb6Zwj2nEXa3yvUQIyWwoCppdlEUWVhOHg5/SeT3gAHu2FAKwHG4pAI9J7kO6Jg==
+"@voiceflow/general-types@1.10.2", "@voiceflow/general-types@^1.2.0":
+  version "1.10.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.10.2.tgz#9853e42971967a9b7bd2d8bc0089cfe4648ffb60"
+  integrity sha512-oWIEtQdiFKb9te/YzpWUZLHl6o0igBipe4hb2tzXI64NcRGwzwqTRY4HS8/J8s9ZwhqsgbB3K3FleEqG7UPSaA==
   dependencies:
-    "@voiceflow/api-sdk" "1.10.1"
+    "@voiceflow/api-sdk" "1.17.1"
 
 "@voiceflow/general-types@1.3.1":
   version "1.3.1"
@@ -1118,13 +1104,6 @@
   integrity sha512-1PzCx2rPHrimDg5KVf/l/IUfAS7adoPM+BZjaZJyllONeXYGFYg92f2kCFkQEn/wHlwl8NnvXhFb920PKE4csQ==
   dependencies:
     "@voiceflow/api-sdk" "1.10.1"
-
-"@voiceflow/general-types@1.7.0":
-  version "1.7.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.7.0.tgz#80dae9761d73a1fe8c4e9ed59629af5b2d9a0fd2"
-  integrity sha512-2+euBWeT4zE46bQN7IhrA7wyFL74EKVe6/vk/0pNgrtgpgP1YsT/FDEEbPUAqwy6wGklQmKU2LG7/BgZfODdVA==
-  dependencies:
-    "@voiceflow/api-sdk" "1.13.0"
 
 "@voiceflow/git-branch-check@^1.0.6":
   version "1.1.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1021,6 +1021,20 @@
     regenerator-runtime "^0.13.5"
     superstruct "^0.10.12"
 
+"@voiceflow/api-sdk@1.16.0":
+  version "1.16.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.16.0.tgz#eb0f2fb03a06f077123bb5f24b78734fef9a8fd6"
+  integrity sha512-7xWmRnX8pnjtus7U2Yc/qutByy9P+Mf++KThOVxLY7LmissP5lyoiJvPWVNdCrgQRhitauO2QpMWUG6Wu1hd1Q==
+  dependencies:
+    "@types/atob" "^2.1.2"
+    "@voiceflow/logger" "^1.1.10"
+    atob "^2.1.2"
+    axios "^0.19.2"
+    core-js "^3.6.5"
+    io-ts "^2.2.8"
+    regenerator-runtime "^0.13.5"
+    superstruct "^0.10.12"
+
 "@voiceflow/api-sdk@1.17.1":
   version "1.17.1"
   resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.17.1.tgz#7843eec956ad8b4ad155fed17b4bbea1eb334360"
@@ -1091,19 +1105,19 @@
     eslint-plugin-sonarjs "^0.4.0"
     eslint-plugin-xss "^0.1.9"
 
+"@voiceflow/general-types@1.10.0":
+  version "1.10.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.10.0.tgz#e97c8f17d14c4cdec472f3c8862900c7142fba0e"
+  integrity sha512-4QU38BMODlla4A9L++xv80mggnNZaclr3IAxOnpHMegjCdkCxs3e3Aqy13EJ1tnnuXFaHT6lcJdltlqzaeoVIw==
+  dependencies:
+    "@voiceflow/api-sdk" "1.16.0"
+
 "@voiceflow/general-types@1.10.2", "@voiceflow/general-types@^1.2.0":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.10.2.tgz#9853e42971967a9b7bd2d8bc0089cfe4648ffb60"
   integrity sha512-oWIEtQdiFKb9te/YzpWUZLHl6o0igBipe4hb2tzXI64NcRGwzwqTRY4HS8/J8s9ZwhqsgbB3K3FleEqG7UPSaA==
   dependencies:
     "@voiceflow/api-sdk" "1.17.1"
-
-"@voiceflow/general-types@1.3.1":
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.3.1.tgz#a45756fbb2040613b6b5bb246e147fb0f2c9fd81"
-  integrity sha512-1PzCx2rPHrimDg5KVf/l/IUfAS7adoPM+BZjaZJyllONeXYGFYg92f2kCFkQEn/wHlwl8NnvXhFb920PKE4csQ==
-  dependencies:
-    "@voiceflow/api-sdk" "1.10.1"
 
 "@voiceflow/git-branch-check@^1.0.6":
   version "1.1.3"
@@ -1146,14 +1160,14 @@
   resolved "https://registry.yarnpkg.com/@voiceflow/prettier-config/-/prettier-config-1.0.4.tgz#fe3ef88f1370f326a844686b57ee15522fc03b02"
   integrity sha512-hVjP3v3uKEmbjen4dGjv4A8EEHjopvzEnNdg8KHFZnvvD1eYu4IvDAyKqoK3xGoacqcLlkBo3abyCzOaHOp0Dg==
 
-"@voiceflow/runtime@1.11.3":
-  version "1.11.3"
-  resolved "https://registry.yarnpkg.com/@voiceflow/runtime/-/runtime-1.11.3.tgz#b34310966f3f750a5368254e06cab925bee852d2"
-  integrity sha512-597ywa31browNmYBfhELTKIUQORzH9t42FoUkDElN47fpo64pbfVgXks8JNY5hb/nk/gu1VbW89lLm3wbE4oHw==
+"@voiceflow/runtime@1.12.0":
+  version "1.12.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/runtime/-/runtime-1.12.0.tgz#1d865cac5f66d54014c197a4cde887642f028251"
+  integrity sha512-9nj5uiyIMVihzZpkk2l+4/U9kMNgNkM/yaVVSUOz2H+cZgnN65U3KcLsIPSY8bL1rqRyeUcZ//LmmuoY9t1DgA==
   dependencies:
     "@types/safe-json-stringify" "^1.1.0"
-    "@voiceflow/api-sdk" "1.10.1"
-    "@voiceflow/general-types" "1.3.1"
+    "@voiceflow/api-sdk" "1.16.0"
+    "@voiceflow/general-types" "1.10.0"
     axios "^0.19.0"
     bluebird "^3.7.2"
     immer "^5.1.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -997,29 +997,15 @@
     semver "^7.3.2"
     tsutils "^3.17.1"
 
-"@voiceflow/alexa-types@1.30.2":
-  version "1.30.2"
-  resolved "https://registry.yarnpkg.com/@voiceflow/alexa-types/-/alexa-types-1.30.2.tgz#6dd74c94f44599d2532962c560da5267b85030ab"
-  integrity sha512-8SjRZ6UsBLdnxlpsWUjrzLSMO5lsdSib+HctGLNjpZPNUy+RxtNb1CkZ9W4oA7WybkHQ6+oZ8G4XnuMEHXVInw==
+"@voiceflow/alexa-types@1.32.2":
+  version "1.32.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/alexa-types/-/alexa-types-1.32.2.tgz#f55533415a7a385adb019ef88cc5119a267ef35c"
+  integrity sha512-vGHXFdxftZvh2uKG0Hy9bTMUiALTS5x2TGnsjyXU9Y/fM4P8vpE0DSVns0+KTGH7QkRNzuA3h3T5hKTQlFrZRA==
   dependencies:
-    "@voiceflow/api-sdk" "1.10.1"
-    "@voiceflow/general-types" "^1.2.0"
+    "@voiceflow/api-sdk" "1.17.1"
+    "@voiceflow/general-types" "1.10.2"
     ask-smapi-model "^1.11.0"
     eslint-plugin-prettier "^3.1.4"
-
-"@voiceflow/api-sdk@1.10.1":
-  version "1.10.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-1.10.1.tgz#c9177eb866a003b786453056cdb11439d820f076"
-  integrity sha512-PEpf0dybn5YCc9Sp2JrYGW5sYGe3dxGJ7QPcTdFUp0Hz/D4ihsisLKEU5LhcRFXQU62o+PlxAQt/u90/QDHHmA==
-  dependencies:
-    "@types/atob" "^2.1.2"
-    "@voiceflow/logger" "^1.1.10"
-    atob "^2.1.2"
-    axios "^0.19.2"
-    core-js "^3.6.5"
-    io-ts "^2.2.8"
-    regenerator-runtime "^0.13.5"
-    superstruct "^0.10.12"
 
 "@voiceflow/api-sdk@1.16.0":
   version "1.16.0"
@@ -1112,7 +1098,7 @@
   dependencies:
     "@voiceflow/api-sdk" "1.16.0"
 
-"@voiceflow/general-types@1.10.2", "@voiceflow/general-types@^1.2.0":
+"@voiceflow/general-types@1.10.2":
   version "1.10.2"
   resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-1.10.2.tgz#9853e42971967a9b7bd2d8bc0089cfe4648ffb60"
   integrity sha512-oWIEtQdiFKb9te/YzpWUZLHl6o0igBipe4hb2tzXI64NcRGwzwqTRY4HS8/J8s9ZwhqsgbB3K3FleEqG7UPSaA==


### PR DESCRIPTION
### Do not merge until all general prototype PRs are not merged!!!

- https://github.com/voiceflow/creator-api/pull/560 - added prototype-programs endpoints, added support for prototype  field in version, replaced TEST_ENDPOINT with PROTOTYPE_ENDPOINT
- https://github.com/voiceflow/server-data-api/pull/37 - removed getTestDiagram and introduced prototype-programs/:programID endpoint
- https://github.com/voiceflow/platform/pull/33 - added PrototypeCloneHandlers, added PrototypeCompiler and compilerType (COMPILE|PROTOTYPE|SURVEY), add inMemoryMode to clone diagram to do not store diagrams
- https://github.com/voiceflow/general-service/pull/9 - introduced compiler endpoint to compile diagrams out of the jobs (will be used in platform services)
- https://github.com/voiceflow/runtime/pull/69 - removed getTestProgram method, updated libs, added platform arg to serverDataAPI (generate-platform-token had hardcoded alexa platform)
- https://github.com/voiceflow/general-runtime/pull/6 - use prototype-programs
- https://github.com/voiceflow/alexa-service/pull/78 - FE