### PR TITLE
fix: display stream pause

### DIFF
--- a/lib/services/alexa/request/error.ts
+++ b/lib/services/alexa/request/error.ts
@@ -10,10 +10,7 @@ const ErrorHandlerGenerator = (metrics: MetricsType): ErrorHandlerType => ({
   handle: (input: HandlerInput, error: Error) => {
     // TODO: fully implement error handler
 
-    console.log('== START ERROR HANDLER ==');
-    console.log(input.requestEnvelope.request);
-    console.error(error);
-    console.log('== END ERROR HANDLER ==');
+    console.error(error, input.requestEnvelope.request.type);
 
     const { versionID } = input.context as { versionID: string };
     metrics.error(versionID);

--- a/lib/services/alexa/request/error.ts
+++ b/lib/services/alexa/request/error.ts
@@ -1,3 +1,4 @@
+/* eslint-disable no-console */
 import { ErrorHandler as ErrorHandlerType, HandlerInput } from 'ask-sdk';
 
 import { MetricsType } from '@/lib/clients/metrics';
@@ -9,8 +10,10 @@ const ErrorHandlerGenerator = (metrics: MetricsType): ErrorHandlerType => ({
   handle: (input: HandlerInput, error: Error) => {
     // TODO: fully implement error handler
 
-    // eslint-disable-next-line no-console
-    console.error(input.requestEnvelope.request.type, JSON.stringify(error));
+    console.log('== START ERROR HANDLER ==');
+    console.log(input.requestEnvelope.request);
+    console.error(error);
+    console.log('== END ERROR HANDLER ==');
 
     const { versionID } = input.context as { versionID: string };
     metrics.error(versionID);

--- a/lib/services/alexa/request/playback/index.ts
+++ b/lib/services/alexa/request/playback/index.ts
@@ -42,9 +42,24 @@ export const PlaybackControllerHandlerGenerator = (utils: typeof utilsObj): Requ
         intent.name = IntentName.FALLBACK;
     }
 
-    request.intent = intent;
+    // the input request object is non-extensible, read only - create a new one
+    const newInput = {
+      ...input,
+      requestEnvelope: {
+        ...input.requestEnvelope,
+        request: {
+          ...input.requestEnvelope.request,
+          type: 'IntentRequest',
+          intent,
+        } as IntentRequest,
+      },
+    };
 
-    return utils.IntentHandler.handle(input);
+    const response = await utils.IntentHandler.handle(newInput);
+    delete response.outputSpeech;
+    delete response.reprompt;
+
+    return response;
   },
 });
 


### PR DESCRIPTION
so it turns out the issue was that the request object was not extensible
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/preventExtensions

we were faking these touch commands as intents for the runtime to process.
Also whenever you handle a `PlaybackController` event, you can't return a speak or reprompt - so just covering that base as well.

Also our error logging SUCKS - updated it to actually show the errors.
