### PR TITLE
fix: extract attributes (CORE-5076)

### DIFF
--- a/lib/services/adapter/index.ts
+++ b/lib/services/adapter/index.ts
@@ -27,7 +27,11 @@ class AdapterManager extends AbstractManager {
     }
   }
 
-  async transformState(state: OldStateRaw, input: HandlerInput): Promise<NewStateRaw | {}> {
+  async transformState(state: OldStateRaw | { attributes: OldStateRaw; id: string }, input: HandlerInput): Promise<NewStateRaw | {}> {
+    if ('attributes' in state) {
+      state = state.attributes;
+    }
+
     try {
       state = beforeContextModifier(state);
 

--- a/tests/lib/services/adapter/index.unit.ts
+++ b/tests/lib/services/adapter/index.unit.ts
@@ -68,6 +68,7 @@ describe('adapterManager unit tests', async () => {
     const tests = [
       { text: 'malformed', old: oldMalformed, new: newMalformed },
       { text: 'hello world', old: oldBasic, new: newBasic },
+      { text: 'hello world wrapped', old: { attributes: oldBasic }, new: newBasic },
       { text: 'wait on interaction', old: oldInteraction, new: newInteraction },
       { text: 'missing attributes', old: oldMissing, new: newMissing },
       { text: 'outputmap', old: oldOutputMap, new: newOutputMap },


### PR DESCRIPTION
saw this error on datadog 
`context adapter err: Cannot read property '0' of undefined`.
Only place where we are using `0` is when accessing the first el of the globals array [here](https://github.com/voiceflow/alexa-client/blob/cec33e0de7ececdf01415b33960993db8bd19275/lib/services/adapter/utils.ts#L122). Looked at the user's session and globals is definitely there. Only way I see this happening is if for some reason the `getPersistentAttributes` returns `{ attributes: state, id: string}` instead of just `state`. Put in a defensive clause for this case.