### PR TITLE
fix: reminder permissions (CORE-000)

### DIFF
--- a/lib/controllers/alexa.ts
+++ b/lib/controllers/alexa.ts
@@ -1,7 +1,6 @@
 import { Validator } from '@voiceflow/backend-utils';
 
 import { AlexaContext } from '@/lib/services/alexa/types';
-import log from '@/logger';
 import { Request } from '@/types';
 
 import { validate } from '../utils';
@@ -30,13 +29,7 @@ class AlexaController extends AbstractController {
       runtimeClient,
     };
 
-    const response = await alexa.skill.invoke(req.body, alexaContext);
-
-    // temporary hard coded for debugging on prod
-    if (req.params.versionID === '6041446c8f74b3001c175b5c') {
-      log.warn('DEBUG 6041446c8f74b3001c175b5c request=%s response=%s', JSON.stringify(req.body.request), JSON.stringify(response));
-    }
-    return response;
+    return alexa.skill.invoke(req.body, alexaContext);
   }
 }
 

--- a/lib/services/alexa/request/intent/index.ts
+++ b/lib/services/alexa/request/intent/index.ts
@@ -1,7 +1,5 @@
 import { RequestHandler } from 'ask-sdk';
 
-import log from '@/logger';
-
 import { AlexaHandlerInput, Request } from '../../types';
 import { buildResponse, buildRuntime, initialize, update } from '../lifecycle';
 import behavior from './behavior';
@@ -27,10 +25,6 @@ export const IntentHandlerGenerator = (utils: typeof utilsObj): RequestHandler =
       await utils.initialize(runtime, input);
     }
 
-    if (runtime.versionID === '6041446c8f74b3001c175b5c') {
-      log.warn('BEFORE 6041446c8f74b3001c175b5c stack=%s', JSON.stringify(runtime.stack.getState()));
-    }
-
     // eslint-disable-next-line no-restricted-syntax
     for (const handler of utils.behavior) {
       if (handler.canHandle(input, runtime)) {
@@ -39,10 +33,6 @@ export const IntentHandlerGenerator = (utils: typeof utilsObj): RequestHandler =
     }
 
     await utils.update(runtime);
-
-    if (runtime.versionID === '6041446c8f74b3001c175b5c') {
-      log.warn('AFTER 6041446c8f74b3001c175b5c stack=%s', JSON.stringify(runtime.stack.getState()));
-    }
 
     return utils.buildResponse(runtime, input);
   },

--- a/lib/services/runtime/handlers/userInfo/utils.ts
+++ b/lib/services/runtime/handlers/userInfo/utils.ts
@@ -48,6 +48,13 @@ export const _ispPermissionGenerator = (apiCall: typeof _alexaApiCall) => async 
   }
 };
 
+export const _remindersPermissions = async (handlerInput?: AlexaHandlerInput): Promise<boolean> =>
+  !!(await handlerInput?.serviceClientFactory
+    ?.getReminderManagementServiceClient()
+    .getReminders()
+    .then(() => true)
+    .catch(() => false));
+
 const _transactionPermissionGenerator = async ({
   result,
   apiCall,
@@ -269,6 +276,7 @@ const utilsObj = {
   _profileNameReadPermission,
   _profileNumberReadPermission,
   _geolocationRead,
+  _remindersPermissions,
 };
 
 export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
@@ -280,6 +288,10 @@ export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
 
   const permissionValue = permission.selected?.value;
   const handlerInput = runtime.turn.get<AlexaHandlerInput>(T.HANDLER_INPUT);
+
+  if (permissionValue === PermissionType.ALEXA_ALERTS_REMINDERS_SKILL_READ_WRITE) {
+    return utils._remindersPermissions(handlerInput);
+  }
 
   if (
     !permissionValue ||
@@ -293,10 +305,6 @@ export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
   const permissionVariable = permission.map_to?.value;
 
   if (permissionValue === PermissionType.ALEXA_DEVICES_ALL_NOTIFICATIONS_WRITE) {
-    return true;
-  }
-
-  if (permissionValue === PermissionType.ALEXA_ALERTS_REMINDERS_SKILL_READ_WRITE) {
     return true;
   }
 

--- a/tests/lib/services/voiceflow/handlers/userInfo/utils.unit.ts
+++ b/tests/lib/services/voiceflow/handlers/userInfo/utils.unit.ts
@@ -73,9 +73,12 @@ describe('user info utils unit test', () => {
 
     it('PERMISSIONS.REMINDERS_READ_WRITE', async () => {
       const permissionValue = PermissionType.ALEXA_ALERTS_REMINDERS_SKILL_READ_WRITE;
-      const runtime = { turn: { get: sinon.stub().returns({}) }, storage: { get: sinon.stub().returns([permissionValue]) } };
+      const handlerInput = 'handler-input';
+      const runtime = { turn: { get: sinon.stub().returns(handlerInput) }, storage: { get: sinon.stub().returns([permissionValue]) } };
       const permission = { selected: { value: permissionValue } };
-      expect(await isPermissionGranted(permission as any, runtime as any, null as any)).to.eql(true);
+      const utils = { _remindersPermissions: sinon.stub().returns(true) };
+      expect(await isPermissionGrantedGenerator(utils as any)(permission as any, runtime as any, null as any)).to.eql(true);
+      expect(utils._remindersPermissions.args).to.eql([[handlerInput]]);
     });
 
     it('PERMISSIONS.ALEXA_HOUSEHOLD_LISTS_READ', async () => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-000**

### Brief description. What is this change?

so amazon decided to apparently invalid their whole permissions event change system, so now our `runtime.storage.get<string[]>(S.PERMISSIONS)` is worthless to check against. The best way to check for permissions is now to actually make a general API call (like .getReminders) and see if it fails or passes

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded