### PR TITLE
feat: upgrade @voiceflow/common (CORE-5362)

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/alexa-types": "1.43.1",
     "@voiceflow/api-sdk": "1.27.1",
     "@voiceflow/backend-utils": "2.2.1",
-    "@voiceflow/common": "6.5.0",
+    "@voiceflow/common": "6.5.1",
     "@voiceflow/general-types": "1.34.5",
     "@voiceflow/logger": "1.5.2",
     "@voiceflow/runtime": "1.24.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -946,6 +946,11 @@
   resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-6.5.0.tgz#68659641bf7e868b4594a640d63072f573b62f1e"
   integrity sha512-6czuZhUs3dGT/5IWI2ejTf/y69BmzG3/PCS0o1YoE0wxGxXPpfBUdelK9ZKCVgk6s89WnuDKYLKmgNWpln2dkw==
 
+"@voiceflow/common@6.5.1":
+  version "6.5.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/common/-/common-6.5.1.tgz#f2a4e54268360e9b6273b7370115ebb050a9490f"
+  integrity sha512-2fC4QTUSftx1uG9b/Lwe4aTpgTvxAI9peQdWvIx848bxneH8QKd6E+BVbhpobW9LACLe2oxoj4PZWNB6qX9d7Q==
+
 "@voiceflow/eslint-config@^2.0.5":
   version "2.0.5"
   resolved "https://registry.yarnpkg.com/@voiceflow/eslint-config/-/eslint-config-2.0.5.tgz#7c167fbb703dddd9db7a10b335ec34d8aeafad76"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5362**

### Brief description. What is this change?

Upgrading `@voiceflow/common` to enable longer variable names.

### Implementation details. How do you make this change?

`yarn upgrade @voiceflow/common@6.5.1`

### Setup information

None

### Deployment Notes

None

### Related PRs

| branch              | PR          |
| ------------------- | ----------- |
| `creator-app` | [link](https://github.com/voiceflow/creator-app/pull/3089) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [x] appropriate tests have been written
- [x] all the dependencies are upgraded