### PR TITLE
fix: prelim events clash

### DIFF
--- a/lib/services/alexa/request/event/runtime.ts
+++ b/lib/services/alexa/request/event/runtime.ts
@@ -1,6 +1,7 @@
 import { Command } from '@voiceflow/api-sdk';
 import { extractFrameCommand } from '@voiceflow/runtime';
 
+import { T } from '@/lib/constants';
 import { AlexaRuntime, EventRequest, RequestType } from '@/lib/services/runtime/types';
 
 export type EventCommand = Command<'event', { event: string; next: string | null; mappings: { path: string; var: string }[] }>;
@@ -70,6 +71,8 @@ export const handleEvent = (utils: typeof utilsObj) => async (runtime: AlexaRunt
 
   runtime.stack.popTo(index + 1);
   runtime.stack.top().setNodeID(command.next);
+
+  runtime.turn.set(T.REQUEST, false);
 
   command.mappings.forEach((mapping) => {
     runtime.variables.set(mapping.var, getVariable(mapping.path, request.payload.data));

--- a/lib/services/alexa/request/lifecycle/update.ts
+++ b/lib/services/alexa/request/lifecycle/update.ts
@@ -16,7 +16,10 @@ const update = async (runtime: AlexaRuntime): Promise<void> => {
     storage.set(S.REPEAT, repeat);
   }
 
-  turn.set(T.REQUEST, runtime.getRequest());
+  if (turn.get(T.REQUEST) !== false) {
+    turn.set(T.REQUEST, runtime.getRequest());
+  }
+
   variables.set(V.TIMESTAMP, Math.floor(Date.now() / 1000));
 
   await runtime.update();

--- a/lib/services/runtime/handlers/state/index.ts
+++ b/lib/services/runtime/handlers/state/index.ts
@@ -1,13 +1,7 @@
 import cancelPaymentStateHandler from './cancelPayment';
 import oneShotIntentHandler from './oneShotIntent';
 import paymentStateHandler from './payment';
-// import preliminaryHandler from './preliminary';
+import preliminaryHandler from './preliminary';
 import streamStateHandler from './stream';
 
-export default () => [
-  oneShotIntentHandler(),
-  paymentStateHandler(),
-  cancelPaymentStateHandler(),
-  streamStateHandler(),
-  // preliminaryHandler()
-];
+export default () => [oneShotIntentHandler(), paymentStateHandler(), cancelPaymentStateHandler(), streamStateHandler(), preliminaryHandler()];


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements CORE-5565**

### Brief description. What is this change?

So basically the handler for the event block actually exists outside of the actual runtime. We have to do this because we can get essentially any type of event from alexa and need to check if there is an event block for it, while still needing to handle certain special events.

But the event block will basically set the stack to the block after it, but the prelim handler will think that event is not handled and pause on that block.

There is probably a cleaner way of doing this

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependendencies are upgraded