### PR TITLE
fix: remove AMAZON builtin prefix on comparison

### DIFF
--- a/lib/services/runtime/handlers/command.ts
+++ b/lib/services/runtime/handlers/command.ts
@@ -19,7 +19,9 @@ export const getCommand = (runtime: Runtime, extractFrame: typeof extractFrameCo
   // don't act on a catchall intent
   if (intentName === IntentName.VOICEFLOW) return null;
 
-  const matcher = (command: Command | null) => command?.intent === intentName;
+  const cleanedIntentName = intentName.replace('AMAZON.', '');
+
+  const matcher = (command: Command | null) => command?.intent === cleanedIntentName;
 
   // If Cancel Intent is not handled turn it into Stop Intent
   // This first loop is AMAZON specific, if cancel intent is not explicitly used anywhere at all, map it to stop intent

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -39,10 +39,11 @@ export const InteractionHandler: HandlerFactory<Node, typeof utilsObj> = (utils)
     let variableMap: SlotMapping[] | null = null;
 
     const { intent } = request.payload;
+    const cleanedIntentName = intent.name.replace('AMAZON.', '');
 
     // check if there is a choice in the node that fulfills intent
     node.interactions.forEach((choice, i: number) => {
-      if (choice.intent && utils.formatIntentName(choice.intent) === intent.name) {
+      if (choice.intent && utils.formatIntentName(choice.intent) === cleanedIntentName) {
         variableMap = choice.mappings ?? null;
         nextId = node.nextIds[choice.nextIdIndex || choice.nextIdIndex === 0 ? choice.nextIdIndex : i];
       }


### PR DESCRIPTION
since moving forward, no builtin intent on the canvas will have the AMAZON. prefix, we want to remove that substring when doing the intent matching 