### PR TITLE
feat: response variable (VF-000)

### DIFF
--- a/lib/constants/flags.ts
+++ b/lib/constants/flags.ts
@@ -40,6 +40,9 @@ export enum Frame {
 
 export enum Variables {
   TIMESTAMP = 'timestamp',
+  SYSTEM = '_system',
+  RESPONSE = '_response',
+  VOICEFLOW = 'voiceflow',
 }
 
 export default {

--- a/lib/services/alexa/request/lifecycle/initialize.ts
+++ b/lib/services/alexa/request/lifecycle/initialize.ts
@@ -9,8 +9,6 @@ import { AlexaRuntime } from '@/lib/services/runtime/types';
 
 import { AlexaHandlerInput } from '../../types';
 
-export const VAR_VF = 'voiceflow';
-
 const utilsObj = {
   resume: {
     createResumeFrame,
@@ -63,13 +61,13 @@ export const initializeGenerator = (utils: typeof utilsObj) => async (runtime: A
     platform: 'alexa',
 
     // hidden system variables (code node only)
-    [VAR_VF]: {
+    [V.VOICEFLOW]: {
       // TODO: implement all exposed voiceflow variables
       permissions: storage.get(S.ALEXA_PERMISSIONS),
       capabilities: storage.get(S.SUPPORTED_INTERFACES),
       events: [],
     },
-    _system: input.requestEnvelope.context.System,
+    [V.SYSTEM]: input.requestEnvelope.context.System,
   });
 
   // initialize all the global variables, as well as slots as global variables
@@ -89,7 +87,7 @@ export const initializeGenerator = (utils: typeof utilsObj) => async (runtime: A
 
   const { session = { type: SessionType.RESTART } } = settings;
   // restart logic
-  const shouldRestart = stack.isEmpty() || session.type === SessionType.RESTART || variables.get<{ resume?: boolean }>(VAR_VF)?.resume === false;
+  const shouldRestart = stack.isEmpty() || session.type === SessionType.RESTART || variables.get<{ resume?: boolean }>(V.VOICEFLOW)?.resume === false;
   if (shouldRestart) {
     // start the stack with just the root flow
     stack.flush();

--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -1,6 +1,8 @@
 import { Response } from 'ask-sdk-model';
+import _isObject from 'lodash/isObject';
+import _mapValues from 'lodash/mapValues';
 
-import { S, T } from '@/lib/constants';
+import { S, T, V } from '@/lib/constants';
 import { responseHandlers } from '@/lib/services/runtime/handlers';
 import { AlexaRuntime } from '@/lib/services/runtime/types';
 
@@ -12,7 +14,7 @@ const utilsObj = {
 };
 
 export const responseGenerator = (utils: typeof utilsObj) => async (runtime: AlexaRuntime, input: AlexaHandlerInput): Promise<Response> => {
-  const { storage, turn } = runtime;
+  const { storage, turn, variables } = runtime;
   const { responseBuilder, attributesManager } = input;
 
   if (runtime.stack.isEmpty()) {
@@ -40,6 +42,13 @@ export const responseGenerator = (utils: typeof utilsObj) => async (runtime: Ale
     if (directives.some(({ type }) => DirectivesInvalidWithAudioPlayer.has(type))) {
       response.directives = directives.filter(({ type }) => !type.startsWith(Request.AUDIO_PLAYER));
     }
+  }
+
+  if (_isObject(variables.get(V.RESPONSE))) {
+    return {
+      ...response,
+      ..._mapValues(variables.get(V.RESPONSE), (v) => (v === null ? undefined : v)),
+    };
   }
 
   return response;

--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -1,6 +1,6 @@
 import { EventType, State } from '@voiceflow/runtime';
 
-import { S, T } from '@/lib/constants';
+import { S, T, V } from '@/lib/constants';
 import { AlexaRuntimeRequest, RequestType } from '@/lib/services/runtime/types';
 import log from '@/logger';
 
@@ -28,6 +28,8 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
   runtime.turn.set(T.PREVIOUS_OUTPUT, runtime.storage.get(S.OUTPUT));
   runtime.storage.set(S.OUTPUT, '');
   runtime.storage.set(S.ACCESS_TOKEN, requestEnvelope.context.System.user.accessToken);
+
+  runtime.variables.set(V.RESPONSE, null);
 
   runtime.setEvent(EventType.stateDidCatch, (error) => log.error('RUNTIME STACK ERROR error=%s', JSON.stringify(error)));
   runtime.setEvent(EventType.handlerDidCatch, (error) => log.error('RUNTIME HANDLER ERROR error=%s', JSON.stringify(error)));

--- a/tests/lib/services/alexa/request/lifecycle/initialize.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/initialize.unit.ts
@@ -2,8 +2,8 @@ import { RepeatType, SessionType, TraceType } from '@voiceflow/general-types';
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { F, S, T } from '@/lib/constants';
-import { initializeGenerator, VAR_VF } from '@/lib/services/alexa/request/lifecycle/initialize';
+import { F, S, T, V } from '@/lib/constants';
+import { initializeGenerator } from '@/lib/services/alexa/request/lifecycle/initialize';
 import { StreamAction } from '@/lib/services/runtime/handlers/stream';
 
 const VERSION_ID = 'version-id';
@@ -141,7 +141,7 @@ describe('initialize lifecycle unit tests', async () => {
           user_id: userId,
           sessions: 1,
           platform: 'alexa',
-          [VAR_VF]: {
+          [V.VOICEFLOW]: {
             events: [],
             permissions,
             capabilities,

--- a/tests/lib/services/alexa/request/lifecycle/response.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/response.unit.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { S, T } from '@/lib/constants';
+import { S, T, V } from '@/lib/constants';
 import { responseGenerator } from '@/lib/services/alexa/request/lifecycle/response';
 
 describe('response lifecycle unit tests', () => {
@@ -23,6 +23,7 @@ describe('response lifecycle unit tests', () => {
       storage: { get: storageGet },
       turn: { get: turnGet, set: sinon.stub() },
       stack: { isEmpty: sinon.stub().returns(true) },
+      variables: { get: sinon.stub().returns(false) },
       getFinalState: sinon.stub().returns(finalState),
     };
     const accessToken = 'access-token';
@@ -56,6 +57,7 @@ describe('response lifecycle unit tests', () => {
       storage: { set: sinon.stub(), get: sinon.stub().returns('speak') },
       turn: { get: sinon.stub().returns(true) },
       stack: { isEmpty: sinon.stub().returns(false) },
+      variables: { get: sinon.stub().returns(false) },
       getFinalState: sinon.stub().returns({}),
     };
     const output = 'output';
@@ -70,5 +72,34 @@ describe('response lifecycle unit tests', () => {
     };
 
     expect(await response(runtime as any, input as any)).to.eql(output);
+  });
+
+  it('response variable', async () => {
+    const utils = { responseHandlers: [] };
+
+    const response = responseGenerator(utils);
+
+    const responseVar = { foo: 'bar', b: 'd', c: null };
+
+    const runtime = {
+      storage: { set: sinon.stub(), get: sinon.stub().returns('speak') },
+      turn: { get: sinon.stub().returns(true) },
+      stack: { isEmpty: sinon.stub().returns(false) },
+      variables: { get: sinon.stub().returns(responseVar) },
+      getFinalState: sinon.stub().returns({}),
+    };
+    const output = { a: 'b', b: 'c' };
+
+    const input = {
+      responseBuilder: {
+        getResponse: sinon.stub().returns(output),
+        speak: sinon.stub().returns({ reprompt: sinon.stub().returns({ withShouldEndSession: sinon.stub() }) }),
+      },
+      requestEnvelope: { runtime: { System: { user: { accessToken: 'access-token' } } } },
+      attributesManager: { setPersistentAttributes: sinon.stub() },
+    };
+
+    expect(await response(runtime as any, input as any)).to.eql({ ...output, ...responseVar, c: undefined });
+    expect(runtime.variables.get.args).to.eql([[V.RESPONSE], [V.RESPONSE]]);
   });
 });

--- a/tests/lib/services/alexa/request/lifecycle/runtime.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/runtime.unit.ts
@@ -1,7 +1,7 @@
 import { expect } from 'chai';
 import sinon from 'sinon';
 
-import { S, T } from '@/lib/constants';
+import { S, T, V } from '@/lib/constants';
 import buildRuntime from '@/lib/services/alexa/request/lifecycle/runtime';
 import { Request } from '@/lib/services/alexa/types';
 import { RequestType } from '@/lib/services/runtime/types';
@@ -12,6 +12,7 @@ describe('runtime lifecycle unit tests', () => {
     const runtime = {
       storage: { set: sinon.stub(), get: sinon.stub().returns('output') },
       turn: { set: sinon.stub() },
+      variables: { set: sinon.stub() },
       setEvent: sinon.stub(),
     };
 
@@ -38,6 +39,7 @@ describe('runtime lifecycle unit tests', () => {
     ]);
     expect(runtime.setEvent.args[0][0]).to.eql('stateDidCatch');
     expect(runtime.setEvent.args[1][0]).to.eql('handlerDidCatch');
+    expect(runtime.variables.set.args).to.eql([[V.RESPONSE, null]]);
   });
 
   it('with event', async () => {
@@ -45,6 +47,7 @@ describe('runtime lifecycle unit tests', () => {
     const runtime = {
       storage: { set: sinon.stub(), get: sinon.stub().returns('output') },
       turn: { set: sinon.stub() },
+      variables: { set: sinon.stub() },
       setEvent: sinon.stub(),
     };
 
@@ -63,6 +66,7 @@ describe('runtime lifecycle unit tests', () => {
     ]);
     expect(runtime.setEvent.args[0][0]).to.eql('stateDidCatch');
     expect(runtime.setEvent.args[1][0]).to.eql('handlerDidCatch');
+    expect(runtime.variables.set.args).to.eql([[V.RESPONSE, null]]);
   });
 
   it('with intent', async () => {
@@ -70,6 +74,7 @@ describe('runtime lifecycle unit tests', () => {
     const runtime = {
       storage: { set: sinon.stub(), get: sinon.stub().returns('output') },
       turn: { set: sinon.stub() },
+      variables: { set: sinon.stub() },
       setEvent: sinon.stub(),
     };
 
@@ -88,5 +93,6 @@ describe('runtime lifecycle unit tests', () => {
     ]);
     expect(runtime.setEvent.args[0][0]).to.eql('stateDidCatch');
     expect(runtime.setEvent.args[1][0]).to.eql('handlerDidCatch');
+    expect(runtime.variables.set.args).to.eql([[V.RESPONSE, null]]);
   });
 });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

this is an emergency fix for Nicolas who is working with a client. Basically Alexa is really really particular about this field "shouldEndSession" in the response, as an escape hatch, through the code block, we will allow the user to override the response object that we normally generate.

I removed the code block endpoint entirely (since the new conditions block is coming in local anyways) mostly because we need to do `shouldEndSession: undefined` and when you send `undefined` over HTTP JSON the variable is just completely unset.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to undertand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
