### PR TITLE
feat: use `secure-json-parse` and `@voiceflow/body-parser` (VF-991)

### DIFF
--- a/backend/api/routers/alexa.ts
+++ b/backend/api/routers/alexa.ts
@@ -1,5 +1,6 @@
-import bodyParser from 'body-parser';
+import bodyParser from '@voiceflow/body-parser';
 import express from 'express';
+import sjson from 'secure-json-parse';
 
 import { BODY_PARSER_SIZE_LIMIT } from '@/backend/constants';
 import { ControllerMap, MiddlewareMap } from '@/lib';
@@ -8,7 +9,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const router = express.Router();
 
   router.use(middlewares.alexa.verifier);
-  router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
+  router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT, customJSONParser: sjson.parse }));
   router.post('/:versionID', controllers.alexa.handler);
 
   return router;

--- a/backend/api/routers/alexa.ts
+++ b/backend/api/routers/alexa.ts
@@ -1,6 +1,5 @@
 import bodyParser from '@voiceflow/body-parser';
 import express from 'express';
-import sjson from 'secure-json-parse';
 
 import { BODY_PARSER_SIZE_LIMIT } from '@/backend/constants';
 import { ControllerMap, MiddlewareMap } from '@/lib';
@@ -9,7 +8,7 @@ export default (middlewares: MiddlewareMap, controllers: ControllerMap) => {
   const router = express.Router();
 
   router.use(middlewares.alexa.verifier);
-  router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT, customJSONParser: sjson.parse }));
+  router.use(bodyParser.json({ limit: BODY_PARSER_SIZE_LIMIT }));
   router.post('/:versionID', controllers.alexa.handler);
 
   return router;

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "@voiceflow/alexa-types": "1.50.15",
     "@voiceflow/api-sdk": "1.31.11",
     "@voiceflow/backend-utils": "2.2.1",
+    "@voiceflow/body-parser": "^1.20.1",
     "@voiceflow/common": "6.5.0",
     "@voiceflow/general-runtime": "1.46.2",
     "@voiceflow/general-types": "1.48.2",
@@ -26,7 +27,6 @@
     "aws-sdk": "^2.586.0",
     "axios": "^0.19.0",
     "bluebird": "^3.7.2",
-    "body-parser": "^1.19.0",
     "compression": "^1.7.4",
     "connect-timeout": "^1.9.0",
     "cookie-parser": "^1.4.4",
@@ -45,6 +45,7 @@
     "pg-format": "^1.0.4",
     "randomstring": "^1.1.5",
     "regenerator-runtime": "^0.13.3",
+    "secure-json-parse": "^2.4.0",
     "words-to-numbers": "^1.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
     "@voiceflow/alexa-types": "1.50.15",
     "@voiceflow/api-sdk": "1.31.11",
     "@voiceflow/backend-utils": "2.2.1",
-    "@voiceflow/body-parser": "^1.20.1",
+    "@voiceflow/body-parser": "^1.21.0",
     "@voiceflow/common": "6.5.0",
     "@voiceflow/general-runtime": "1.46.2",
     "@voiceflow/general-types": "1.48.2",
@@ -45,7 +45,6 @@
     "pg-format": "^1.0.4",
     "randomstring": "^1.1.5",
     "regenerator-runtime": "^0.13.3",
-    "secure-json-parse": "^2.4.0",
     "words-to-numbers": "^1.5.1"
   },
   "devDependencies": {

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,6 +1052,22 @@
     rate-limiter-flexible "^2.2.2"
     sinon "^10.0.0"
 
+"@voiceflow/body-parser@^1.20.1":
+  version "1.20.1"
+  resolved "https://registry.yarnpkg.com/@voiceflow/body-parser/-/body-parser-1.20.1.tgz#469901095c0585457f311f0c60c54e707f629b54"
+  integrity sha512-I4VCtPE/ful1WfFkO9gBdKeRcoAflvPAFHSTMvwm4z1/SiruCFTNNN+nAOZyxcB3VBP8BJy2y/cWDvfPAhjLfQ==
+  dependencies:
+    bytes "3.1.0"
+    content-type "~1.0.4"
+    debug "2.6.9"
+    depd "~1.1.2"
+    http-errors "1.7.3"
+    iconv-lite "0.4.24"
+    on-finished "~2.3.0"
+    qs "6.9.3"
+    raw-body "2.4.1"
+    type-is "~1.6.18"
+
 "@voiceflow/commitlint-config@^1.0.1":
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/@voiceflow/commitlint-config/-/commitlint-config-1.0.1.tgz#e9513aa348d5e88ff064022e2dae8d0d7e227f6a"
@@ -4325,17 +4341,7 @@ http-errors@1.7.2:
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
 
-http-errors@~1.6.1:
-  version "1.6.3"
-  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
-  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
-  dependencies:
-    depd "~1.1.2"
-    inherits "2.0.3"
-    setprototypeof "1.1.0"
-    statuses ">= 1.4.0 < 2"
-
-http-errors@~1.7.2:
+http-errors@1.7.3, http-errors@~1.7.2:
   version "1.7.3"
   resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.7.3.tgz#6c619e4f9c60308c38519498c14fbb10aacebb06"
   integrity sha512-ZTTX0MWrsQ2ZAhA1cejAwDLycFsd7I7nVtnkT3Ol0aqodaKW+0CTZDQ1uBv5whptCnc8e8HeRRJxRs0kmm/Qfw==
@@ -4345,6 +4351,16 @@ http-errors@~1.7.2:
     setprototypeof "1.1.1"
     statuses ">= 1.5.0 < 2"
     toidentifier "1.0.0"
+
+http-errors@~1.6.1:
+  version "1.6.3"
+  resolved "https://registry.yarnpkg.com/http-errors/-/http-errors-1.6.3.tgz#8b55680bb4be283a0b5bf4ea2e38580be1d9320d"
+  integrity sha1-i1VoC7S+KDoLW/TqLjhYC+HZMg0=
+  dependencies:
+    depd "~1.1.2"
+    inherits "2.0.3"
+    setprototypeof "1.1.0"
+    statuses ">= 1.4.0 < 2"
 
 http-signature@~1.2.0:
   version "1.2.0"
@@ -6631,6 +6647,11 @@ qs@6.7.0:
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.7.0.tgz#41dc1a015e3d581f1621776be31afb2876a9b1bc"
   integrity sha512-VCdBRNFTX1fyE7Nb6FYoURo/SPe62QCaAyzJvUjwRaIsc+NePBEniHlvxFmmX56+HZphIGtV0XeCirBtpDrTyQ==
 
+qs@6.9.3:
+  version "6.9.3"
+  resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.3.tgz#bfadcd296c2d549f1dffa560619132c977f5008e"
+  integrity sha512-EbZYNarm6138UKKq46tdx08Yo/q9ZhFoAXAI1meAFd2GtbRDhbZY2WQSICskT0c5q99aFzLG1D4nvTk9tqfXIw==
+
 qs@^6.5.1:
   version "6.9.4"
   resolved "https://registry.yarnpkg.com/qs/-/qs-6.9.4.tgz#9090b290d1f91728d3c22e54843ca44aea5ab687"
@@ -6698,6 +6719,16 @@ raw-body@2.4.0:
   dependencies:
     bytes "3.1.0"
     http-errors "1.7.2"
+    iconv-lite "0.4.24"
+    unpipe "1.0.0"
+
+raw-body@2.4.1:
+  version "2.4.1"
+  resolved "https://registry.yarnpkg.com/raw-body/-/raw-body-2.4.1.tgz#30ac82f98bb5ae8c152e67149dac8d55153b168c"
+  integrity sha512-9WmIKF6mkvA0SLmA2Knm9+qj89e+j1zqgyn8aXGd7+nAduPoqgI9lO57SAZNn/Byzo5P7JhXTyg9PzaJbH73bA==
+  dependencies:
+    bytes "3.1.0"
+    http-errors "1.7.3"
     iconv-lite "0.4.24"
     unpipe "1.0.0"
 
@@ -7142,6 +7173,11 @@ scss-parser@^1.0.4:
   dependencies:
     invariant "2.2.4"
     lodash "^4.17.4"
+
+secure-json-parse@^2.4.0:
+  version "2.4.0"
+  resolved "https://registry.yarnpkg.com/secure-json-parse/-/secure-json-parse-2.4.0.tgz#5aaeaaef85c7a417f76271a4f5b0cc3315ddca85"
+  integrity sha512-Q5Z/97nbON5t/L/sH6mY2EacfjVGwrCcSi5D3btRO2GZ8pf1K1UN7Z9H5J57hjVU2Qzxr1xO+FmBhOvEkzCMmg==
 
 seed-random@^2.2.0:
   version "2.2.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -1052,10 +1052,10 @@
     rate-limiter-flexible "^2.2.2"
     sinon "^10.0.0"
 
-"@voiceflow/body-parser@^1.20.1":
-  version "1.20.1"
-  resolved "https://registry.yarnpkg.com/@voiceflow/body-parser/-/body-parser-1.20.1.tgz#469901095c0585457f311f0c60c54e707f629b54"
-  integrity sha512-I4VCtPE/ful1WfFkO9gBdKeRcoAflvPAFHSTMvwm4z1/SiruCFTNNN+nAOZyxcB3VBP8BJy2y/cWDvfPAhjLfQ==
+"@voiceflow/body-parser@^1.21.0":
+  version "1.21.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/body-parser/-/body-parser-1.21.0.tgz#3ff37a61a9271e0ab7dca48733806e2515c2b6db"
+  integrity sha512-2vH9AiOlRB9utD3hilefHXcBw6HkVRbmltaG1/6mvqmoA7R+SSjR4SQlYHTADtdoHpvuWQ7tWLkvsfVtfa47/g==
   dependencies:
     bytes "3.1.0"
     content-type "~1.0.4"
@@ -1066,6 +1066,7 @@
     on-finished "~2.3.0"
     qs "6.9.3"
     raw-body "2.4.1"
+    secure-json-parse "^2.4.0"
     type-is "~1.6.18"
 
 "@voiceflow/commitlint-config@^1.0.1":


### PR DESCRIPTION
**Fixes or implements VF-991**

### Brief description. What is this change?

Replace `body-parser` with [voiceflow/body-parser](https://github.com/voiceflow/body-parser) and use `secure-json-parse` to avoid prototype poisoning vulnerabilities

### Related PRs

| branch              | PR          |
| ------------------- | ----------- |
| voiceflow/alexa-service#149     | [link](https://github.com/voiceflow/google-service/pull/149) |
| voiceflow/creator-api#692     | [link](https://github.com/voiceflow/creator-api/pull/692) |
| voiceflow/general-service#110     | [link](https://github.com/voiceflow/general-service/pull/110) |
| voiceflow/google-service#99     | [link](https://github.com/voiceflow/google-service/pull/99) |
| voiceflow/canvas-export#45     | [link](https://github.com/voiceflow/canvas-export/pull/45) |
| voiceflow/backend-template#14     | [link](https://github.com/voiceflow/backend-template/pull/14) |
| voiceflow/alexa-runtime#168     | [link](https://github.com/voiceflow/alexa-runtime/pull/168) |
| voiceflow/general-runtime#136 | [link](https://github.com/voiceflow/general-runtime/pull/136) |
| voiceflow/google-runtime#115     | [link](https://github.com/voiceflow/google-runtime/pull/115) |
| voiceflow/server-data-api#57     | [link](https://github.com/voiceflow/server-data-api/pull/57) |
| voiceflow/luis-authoring-service#73     | [link](https://github.com/voiceflow/luis-authoring-service/pull/73) |


### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
