### PR TITLE
fix: clean ingest service (VF-000)

### DIFF
--- a/lib/constants/flags.ts
+++ b/lib/constants/flags.ts
@@ -20,7 +20,6 @@ export enum Storage {
 
 export enum Turn {
   AUDIO = 'play',
-  TURNID = 'turnid',
   PERMISSION_CARD = 'permissionCard',
   ACCOUNT_LINKING = 'accountLinking',
   END = 'end',

--- a/lib/services/alexa/request/audioPlayerEvent.ts
+++ b/lib/services/alexa/request/audioPlayerEvent.ts
@@ -72,7 +72,7 @@ export const AudioPlayerEventHandlerGenerator = (utils: typeof utilsObj): Reques
           const tempRuntime = runtimeClient.createRuntime(versionID, rawState as State);
           tempRuntime.storage.set(S.STREAM_PLAY, { ...tempRuntime.storage.get<StreamPlay>(S.STREAM_PLAY), action: StreamAction.NEXT });
 
-          await utils.update(tempRuntime, input);
+          await utils.update(tempRuntime);
 
           if (tempRuntime.storage.get<StreamPlay>(S.STREAM_PLAY)?.action === StreamAction.START) {
             const { url, token, metaData } = utils._streamMetaData(tempRuntime.storage.get<StreamPlay>(S.STREAM_PLAY)!);

--- a/lib/services/alexa/request/intent/index.ts
+++ b/lib/services/alexa/request/intent/index.ts
@@ -32,7 +32,7 @@ export const IntentHandlerGenerator = (utils: typeof utilsObj): RequestHandler =
       }
     }
 
-    await utils.update(runtime, input);
+    await utils.update(runtime);
 
     return utils.buildResponse(runtime, input);
   },

--- a/lib/services/alexa/request/launch.ts
+++ b/lib/services/alexa/request/launch.ts
@@ -26,7 +26,7 @@ export const LaunchHandlerGenerator = (utils: typeof utilsObj): RequestHandler =
 
     await utils.initialize(runtime, input);
 
-    await utils.update(runtime, input);
+    await utils.update(runtime);
 
     return utils.buildResponse(runtime, input);
   },

--- a/lib/services/alexa/request/lifecycle/update.ts
+++ b/lib/services/alexa/request/lifecycle/update.ts
@@ -1,13 +1,9 @@
 import { RepeatType } from '@voiceflow/general-types';
 
-import { Event, RequestType } from '@/lib/clients/ingest-client';
 import { S, T, V } from '@/lib/constants';
 import { AlexaRuntime } from '@/lib/services/runtime/types';
-import logger from '@/logger';
 
-import { AlexaHandlerInput } from '../../types';
-
-const update = async (runtime: AlexaRuntime, input: AlexaHandlerInput): Promise<void> => {
+const update = async (runtime: AlexaRuntime): Promise<void> => {
   const { turn, variables, storage } = runtime;
   const repeatNumber = storage?.get(S.REPEAT);
 
@@ -22,21 +18,6 @@ const update = async (runtime: AlexaRuntime, input: AlexaHandlerInput): Promise<
   variables.set(V.TIMESTAMP, Math.floor(Date.now() / 1000));
 
   await runtime.update();
-  try {
-    // Track response on analytics system
-    const turnID = await runtime.services.analyticsClient.track({
-      id: runtime.getVersionID(),
-      event: Event.TURN,
-      request: input?.requestEnvelope?.request?.type === 'LaunchRequest' ? RequestType.LAUNCH : RequestType.REQUEST,
-      payload: runtime.getRequest(),
-      sessionid: input.requestEnvelope.session?.sessionId,
-      metadata: runtime.getFinalState(),
-      timestamp: new Date(),
-    });
-    turn.set(T.TURNID, turnID);
-  } catch (error) {
-    logger.error(error);
-  }
 };
 
 export default update;

--- a/tests/lib/services/alexa/request/intent/index.unit.ts
+++ b/tests/lib/services/alexa/request/intent/index.unit.ts
@@ -36,7 +36,7 @@ describe('intent handler unit tests', () => {
       expect(await handler.handle(input as any)).to.eql(output);
       expect(utils.buildRuntime.args).to.eql([[input]]);
       expect(utils.initialize.args).to.eql([[runtime, input]]);
-      expect(utils.update.args).to.eql([[runtime, input]]);
+      expect(utils.update.args).to.eql([[runtime]]);
       expect(utils.buildResponse.args).to.eql([[runtime, input]]);
     });
 

--- a/tests/lib/services/alexa/request/launch.unit.ts
+++ b/tests/lib/services/alexa/request/launch.unit.ts
@@ -35,7 +35,7 @@ describe('launch handler unit tests', () => {
       expect(await handler.handle(input as any)).to.eql(output);
       expect(utils.buildRuntime.args).to.eql([[input]]);
       expect(utils.initialize.args).to.eql([[runtime, input]]);
-      expect(utils.update.args).to.eql([[runtime, input]]);
+      expect(utils.update.args).to.eql([[runtime]]);
       expect(utils.buildResponse.args).to.eql([[runtime, input]]);
     });
   });

--- a/tests/lib/services/alexa/request/lifecycle/update.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/update.unit.ts
@@ -25,43 +25,13 @@ describe('update lifecycle unit tests', () => {
         turn: { set: sinon.stub() },
         update: sinon.stub(),
         getRequest: sinon.stub().returns(request),
-        services: {
-          analyticsClient: {
-            identify: sinon.stub().returns(request),
-            track: sinon.stub().returns(request),
-          },
-        },
         getVersionID: sinon.stub().returns(versionID),
         getFinalState: sinon.stub().returns(request),
       };
 
-      const input = {
-        requestEnvelope: {
-          session: {
-            sessionId: 'session.id',
-          },
-        },
-      };
-      await update(runtime as any, input as any);
-      const { timestamp } = runtime.services.analyticsClient.track.args[0][0];
-      expect(runtime.turn.set.args).to.eql([
-        [T.REQUEST, request],
-        [T.TURNID, request],
-      ]);
+      await update(runtime as any);
+      expect(runtime.turn.set.args).to.eql([[T.REQUEST, request]]);
       expect(runtime.variables.set.args).to.eql([[V.TIMESTAMP, Math.floor(clock.now / 1000)]]);
-      expect(runtime.services.analyticsClient.track.args).to.eql([
-        [
-          {
-            id: versionID,
-            event: Event.TURN,
-            request: RequestType.REQUEST,
-            payload: request,
-            sessionid: input.requestEnvelope.session.sessionId,
-            metadata: request,
-            timestamp,
-          },
-        ],
-      ]);
       expect(runtime.update.callCount).to.eql(1);
     });
   });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

There shouldn't be a reason why we need to separate the `Event.TURN` from the `Event.INTERACT` - they are both generated after the actual runtime has executed and generated a new state. 

Previously the `Event.TURN` call in update was actually blocking until the request resolves (`await`)
Now both analytics tracking calls are async (not in the same eventloop thread).

Also we were doing this in the response before:
```
try {
  ....
  runtime.services.analyticsClient.track ...
} catch (error) {
 ....
}
```
The was no `await` on the promise above so it wouldn't be catching anyways.


Also its nicer to just put them in one place. We could probably do both as a singular API call if we change the ingest service.

### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] title of PR reflects the branch name
- [ ] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
