### PR TITLE
feat: add `PRIVATE_LOGS` boolean env var (VF-1479)

### DIFF
--- a/config.ts
+++ b/config.ts
@@ -12,8 +12,8 @@ const CONFIG: Config = {
   PORT: getRequiredProcessEnv('PORT'),
   CLOUD_ENV,
   ERROR_RESPONSE_MS: Number(getOptionalProcessEnv('ERROR_RESPONSE_MS', (10 * 1000).toString())),
-
   IS_PRIVATE_CLOUD: NODE_ENV === 'production' && CLOUD_ENV !== 'public',
+  PRIVATE_LOGS: !!getOptionalProcessEnv('PRIVATE_LOGS', false.toString()),
 
   AWS_ACCESS_KEY_ID: getOptionalProcessEnv('AWS_ACCESS_KEY_ID'),
   AWS_SECRET_ACCESS_KEY: getOptionalProcessEnv('AWS_SECRET_ACCESS_KEY'),

--- a/lib/services/alexa/request/sessionEnded.ts
+++ b/lib/services/alexa/request/sessionEnded.ts
@@ -1,10 +1,12 @@
 import { RequestHandler } from 'ask-sdk';
 import { SessionEndedRequest } from 'ask-sdk-model';
 
+import CONFIG from '@/config';
 import { S } from '@/lib/constants';
 import { DisplayInfo } from '@/lib/services/runtime/handlers/display/types';
 import log from '@/logger';
 
+import { NewStateVariables } from '../../adapter/types';
 import { AlexaHandlerInput } from '../types';
 import { updateRuntime } from '../utils';
 
@@ -38,6 +40,12 @@ export const SessionEndedHandlerGenerator = (utils: typeof utilsObj): RequestHan
 
     await utils.updateRuntime(input, (runtime) => {
       if (errorType === ErrorType.INVALID_RESPONSE || errorType === ErrorType.INTERNAL_SERVICE_ERROR) {
+        const variables = runtime.variables.getState();
+
+        if (CONFIG.PRIVATE_LOGS && variables?._system?.apiAccessToken) {
+          (variables as NewStateVariables)._system.apiAccessToken = '***';
+        }
+
         utils.log.warn(
           [
             'SESSION ENDED',
@@ -45,7 +53,7 @@ export const SessionEndedHandlerGenerator = (utils: typeof utilsObj): RequestHan
             `error=${JSON.stringify(request.error)},`,
             `storage=${JSON.stringify(runtime.storage.getState())},`,
             `turn=${JSON.stringify(runtime.turn.getState())},`,
-            `variables=${JSON.stringify(runtime.variables.getState())},`,
+            `variables=${JSON.stringify(variables)},`,
             `stack=${JSON.stringify(runtime.stack.getState())},`,
             `trace=${JSON.stringify(runtime.trace.get())}`,
           ].join(' ')

--- a/types.ts
+++ b/types.ts
@@ -7,6 +7,8 @@ export interface Config {
   CLOUD_ENV: string | null;
   IS_PRIVATE_CLOUD: boolean;
   ERROR_RESPONSE_MS: number;
+  /** Censor certain sensitive info (ex. API access tokens) */
+  PRIVATE_LOGS: boolean;
 
   AWS_ACCESS_KEY_ID: string | null;
   AWS_SECRET_ACCESS_KEY: string | null;


### PR DESCRIPTION
**Fixes or implements VF-1479**

### Brief description. What is this change?

Adds a `PRIVATE_LOGS` boolean environment variable whether to censor certain sensitive fields in logs (ex. API keys)

### Implementation details. How do you make this change?

Only one instance of a sensitive key was reported, so that specific spot was updated to censor it.

### Deployment Notes

Set the `PRIVATE_LOGS` environment variable to the string `true` to enable this option.
The option is casted from a string to a boolean, so any string, even `false` will enable it.
Only a [falsy string](https://developer.mozilla.org/en-US/docs/Glossary/Falsy#:~:text=%22%22%2C%20%27%27%2C%20%60%60-,Empty%20string%20value.,-null) will disable it, in JS this means an empty string.
The default value is to leave it disabled.

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded
