### PR TITLE
feat: add amazon pay to user info step (VF-1845)

### DIFF
--- a/lib/services/runtime/handlers/userInfo/utils.ts
+++ b/lib/services/runtime/handlers/userInfo/utils.ts
@@ -266,6 +266,16 @@ export const _geolocationRead = async (
   return true;
 };
 
+export const _amazonPayRead = async (handlerInput: AlexaHandlerInput): Promise<boolean> => {
+  const skillPermissionGranted = handlerInput.requestEnvelope.context.System.user.permissions?.scopes?.['payments:autopay_consent'].status;
+
+  if (skillPermissionGranted !== 'GRANTED') {
+    return false;
+  }
+
+  return true;
+};
+
 const utilsObj = {
   _ispPermission: _ispPermissionGenerator(_alexaApiCall),
   _productPermission,
@@ -276,6 +286,7 @@ const utilsObj = {
   _profileNumberReadPermission,
   _geolocationRead,
   _remindersPermissions,
+  _amazonPayRead,
 };
 
 export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
@@ -297,7 +308,8 @@ export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
     !handlerInput ||
     ((!Array.isArray(runtime.storage.get<string[]>(S.PERMISSIONS)) || !runtime.storage.get<string[]>(S.PERMISSIONS)!.includes(permissionValue)) &&
       !permissionValue.startsWith('UNOFFICIAL') &&
-      !permissionValue.startsWith('alexa::person_id'))
+      !permissionValue.startsWith('alexa::person_id') &&
+      !permissionValue.startsWith('payments:autopay_consent'))
   )
     return false;
 
@@ -345,6 +357,10 @@ export const isPermissionGrantedGenerator = (utils: typeof utilsObj) => async (
 
   if (permissionValue === Node.PermissionType.ALEXA_DEVICES_ALL_GEOLOCATION_READ) {
     return utils._geolocationRead(handlerInput, permissionVariable, variables);
+  }
+
+  if (permissionValue === Node.PermissionType.PAYMENTS_AUTO_PAY_CONSENT) {
+    return utils._amazonPayRead(handlerInput);
   }
 
   return false;

--- a/lib/services/runtime/handlers/userInfo/utils.ts
+++ b/lib/services/runtime/handlers/userInfo/utils.ts
@@ -269,11 +269,7 @@ export const _geolocationRead = async (
 export const _amazonPayRead = async (handlerInput: AlexaHandlerInput): Promise<boolean> => {
   const skillPermissionGranted = handlerInput.requestEnvelope.context.System.user.permissions?.scopes?.['payments:autopay_consent'].status;
 
-  if (skillPermissionGranted !== 'GRANTED') {
-    return false;
-  }
-
-  return true;
+  return skillPermissionGranted === 'GRANTED';
 };
 
 const utilsObj = {

--- a/tests/lib/clients/analytics.unit.ts
+++ b/tests/lib/clients/analytics.unit.ts
@@ -8,106 +8,89 @@ describe('Analytics client unit tests', () => {
   // describe('Identify', () => {
   //   it('works', () => {
   //     const config = {};
-
   //     const rudderstack = { identify: sinon.stub() };
-
   //     const client = AnalyticsClient(config as any);
-
   //     (client as any).rudderstackClient = rudderstack;
-
   //     client.identify('user id');
-
   //     expect(rudderstack.identify.callCount).to.eql(1);
   //     expect(rudderstack.identify.getCall(0).args).to.deep.eq([{ userId: 'user id' }]);
   //   });
   // });
-
-  describe('Track', () => {
-    it('throws on unknown events', () => {
-      const client = AnalyticsClient({ config: {} } as any);
-      const metadata = {
-        data: {
-          reqHeaders: {},
-          locale: 'locale',
-        },
-        stack: {},
-        storage: {},
-        variables: {},
-      };
-
-      const payload = {};
-
-      expect(
-        client.track({
-          id: 'id',
-          event: 'Unknow event' as Event,
-          request: RequestType.REQUEST,
-          payload: payload as any,
-          sessionid: 'session.id',
-          metadata: metadata as any,
-          timestamp: new Date(),
-        })
-      ).to.eventually.rejectedWith(RangeError);
-    });
-
-    // it('works with interact events', () => {
-    //   const config = {
-    //     ANALYTICS_WRITE_KEY: 'write key',
-    //     ANALYTICS_ENDPOINT: 'http://localhost/analytics',
-    //     INGEST_WEBHOOK_ENDPOINT: 'http://localhost/ingest',
-    //   };
-
-    //   const metadata = {
-    //     data: {
-    //       reqHeaders: {},
-    //       locale: 'locale',
-    //     },
-    //     stack: {},
-    //     storage: {},
-    //     variables: {},
-    //   };
-
-    //   const payload = {};
-
-    //   const rudderstack = { track: sinon.stub() };
-
-    //   const client = AnalyticsClient(config as any);
-
-    //   (client as any).rudderstackClient = rudderstack;
-
-    //   const ingestClient = { doIngest: sinon.stub() };
-
-    //   (client as any).ingestClient = ingestClient;
-    //   const timestamp = new Date();
-    //   client.track({
-    //     id: 'id',
-    //     event: Event.INTERACT,
-    //     request: RequestType.REQUEST,
-    //     payload: payload as any,
-    //     sessionid: 'session.id',
-    //     metadata: metadata as any,
-    //     timestamp,
-    //   });
-
-    //   expect(rudderstack.track.callCount).to.eql(1);
-    //   expect(rudderstack.track.getCall(0).args).to.deep.eq([
-    //     {
-    //       userId: 'id',
-    //       event: Event.INTERACT,
-    //       properties: {
-    //         metadata: {
-    //           eventId: Event.INTERACT,
-    //           request: {
-    //             type: RequestType.REQUEST,
-    //             payload: {},
-    //             format: 'request',
-    //             turn_id: undefined,
-    //             timestamp: timestamp.toISOString(),
-    //           },
-    //         },
-    //       },
-    //     },
-    //   ]);
-    // });
-  });
+  // describe('Track', () => {
+  //   it('throws on unknown events', () => {
+  //     const client = AnalyticsClient({ config: {} } as any);
+  //     const metadata = {
+  //       data: {
+  //         reqHeaders: {},
+  //         locale: 'locale',
+  //       },
+  //       stack: {},
+  //       storage: {},w
+  //       variables: {},
+  //     };
+  //     const payload = {};
+  //     expect(
+  //       client.track({
+  //         id: 'id',
+  //         event: 'Unknow event' as Event,
+  //         request: RequestType.REQUEST,
+  //         payload: payload as any,
+  //         sessionid: 'session.id',
+  //         metadata: metadata as any,
+  //         timestamp: new Date(),
+  //       })
+  //     ).to.eventually.rejectedWith(RangeError);
+  //   });
+  //   // it('works with interact events', () => {
+  //   //   const config = {
+  //   //     ANALYTICS_WRITE_KEY: 'write key',
+  //   //     ANALYTICS_ENDPOINT: 'http://localhost/analytics',
+  //   //     INGEST_WEBHOOK_ENDPOINT: 'http://localhost/ingest',
+  //   //   };
+  //   //   const metadata = {
+  //   //     data: {
+  //   //       reqHeaders: {},
+  //   //       locale: 'locale',
+  //   //     },
+  //   //     stack: {},
+  //   //     storage: {},
+  //   //     variables: {},
+  //   //   };
+  //   //   const payload = {};
+  //   //   const rudderstack = { track: sinon.stub() };
+  //   //   const client = AnalyticsClient(config as any);
+  //   //   (client as any).rudderstackClient = rudderstack;
+  //   //   const ingestClient = { doIngest: sinon.stub() };
+  //   //   (client as any).ingestClient = ingestClient;
+  //   //   const timestamp = new Date();
+  //   //   client.track({
+  //   //     id: 'id',
+  //   //     event: Event.INTERACT,
+  //   //     request: RequestType.REQUEST,
+  //   //     payload: payload as any,
+  //   //     sessionid: 'session.id',
+  //   //     metadata: metadata as any,
+  //   //     timestamp,
+  //   //   });
+  //   //   expect(rudderstack.track.callCount).to.eql(1);
+  //   //   expect(rudderstack.track.getCall(0).args).to.deep.eq([
+  //   //     {
+  //   //       userId: 'id',
+  //   //       event: Event.INTERACT,
+  //   //       properties: {
+  //   //         metadata: {
+  //   //           eventId: Event.INTERACT,
+  //   //           request: {
+  //   //             type: RequestType.REQUEST,
+  //   //             payload: {},
+  //   //             format: 'request',
+  //   //             turn_id: undefined,
+  //   //             timestamp: timestamp.toISOString(),
+  //   //           },
+  //   //         },
+  //   //       },
+  //   //     },
+  //   //   ]);
+  //   // });
+  // });
 });

--- a/tests/lib/clients/analytics.unit.ts
+++ b/tests/lib/clients/analytics.unit.ts
@@ -8,89 +8,106 @@ describe('Analytics client unit tests', () => {
   // describe('Identify', () => {
   //   it('works', () => {
   //     const config = {};
+
   //     const rudderstack = { identify: sinon.stub() };
+
   //     const client = AnalyticsClient(config as any);
+
   //     (client as any).rudderstackClient = rudderstack;
+
   //     client.identify('user id');
+
   //     expect(rudderstack.identify.callCount).to.eql(1);
   //     expect(rudderstack.identify.getCall(0).args).to.deep.eq([{ userId: 'user id' }]);
   //   });
   // });
-  // describe('Track', () => {
-  //   it('throws on unknown events', () => {
-  //     const client = AnalyticsClient({ config: {} } as any);
-  //     const metadata = {
-  //       data: {
-  //         reqHeaders: {},
-  //         locale: 'locale',
-  //       },
-  //       stack: {},
-  //       storage: {},w
-  //       variables: {},
-  //     };
-  //     const payload = {};
-  //     expect(
-  //       client.track({
-  //         id: 'id',
-  //         event: 'Unknow event' as Event,
-  //         request: RequestType.REQUEST,
-  //         payload: payload as any,
-  //         sessionid: 'session.id',
-  //         metadata: metadata as any,
-  //         timestamp: new Date(),
-  //       })
-  //     ).to.eventually.rejectedWith(RangeError);
-  //   });
-  //   // it('works with interact events', () => {
-  //   //   const config = {
-  //   //     ANALYTICS_WRITE_KEY: 'write key',
-  //   //     ANALYTICS_ENDPOINT: 'http://localhost/analytics',
-  //   //     INGEST_WEBHOOK_ENDPOINT: 'http://localhost/ingest',
-  //   //   };
-  //   //   const metadata = {
-  //   //     data: {
-  //   //       reqHeaders: {},
-  //   //       locale: 'locale',
-  //   //     },
-  //   //     stack: {},
-  //   //     storage: {},
-  //   //     variables: {},
-  //   //   };
-  //   //   const payload = {};
-  //   //   const rudderstack = { track: sinon.stub() };
-  //   //   const client = AnalyticsClient(config as any);
-  //   //   (client as any).rudderstackClient = rudderstack;
-  //   //   const ingestClient = { doIngest: sinon.stub() };
-  //   //   (client as any).ingestClient = ingestClient;
-  //   //   const timestamp = new Date();
-  //   //   client.track({
-  //   //     id: 'id',
-  //   //     event: Event.INTERACT,
-  //   //     request: RequestType.REQUEST,
-  //   //     payload: payload as any,
-  //   //     sessionid: 'session.id',
-  //   //     metadata: metadata as any,
-  //   //     timestamp,
-  //   //   });
-  //   //   expect(rudderstack.track.callCount).to.eql(1);
-  //   //   expect(rudderstack.track.getCall(0).args).to.deep.eq([
-  //   //     {
-  //   //       userId: 'id',
-  //   //       event: Event.INTERACT,
-  //   //       properties: {
-  //   //         metadata: {
-  //   //           eventId: Event.INTERACT,
-  //   //           request: {
-  //   //             type: RequestType.REQUEST,
-  //   //             payload: {},
-  //   //             format: 'request',
-  //   //             turn_id: undefined,
-  //   //             timestamp: timestamp.toISOString(),
-  //   //           },
-  //   //         },
-  //   //       },
-  //   //     },
-  //   //   ]);
-  //   // });
-  // });
+
+  describe('Track', () => {
+    it('throws on unknown events', () => {
+      const client = AnalyticsClient({ config: {} } as any);
+      const metadata = {
+        data: {
+          reqHeaders: {},
+          locale: 'locale',
+        },
+        stack: {},
+        storage: {},
+        variables: {},
+      };
+
+      const payload = {};
+
+      expect(
+        client.track({
+          id: 'id',
+          event: 'Unknow event' as Event,
+          request: RequestType.REQUEST,
+          payload: payload as any,
+          sessionid: 'session.id',
+          metadata: metadata as any,
+          timestamp: new Date(),
+        })
+      ).to.eventually.rejectedWith(RangeError);
+    });
+
+    // it('works with interact events', () => {
+    //   const config = {
+    //     ANALYTICS_WRITE_KEY: 'write key',
+    //     ANALYTICS_ENDPOINT: 'http://localhost/analytics',
+    //     INGEST_WEBHOOK_ENDPOINT: 'http://localhost/ingest',
+    //   };
+
+    //   const metadata = {
+    //     data: {
+    //       reqHeaders: {},
+    //       locale: 'locale',
+    //     },
+    //     stack: {},
+    //     storage: {},
+    //     variables: {},
+    //   };
+
+    //   const payload = {};
+
+    //   const rudderstack = { track: sinon.stub() };
+
+    //   const client = AnalyticsClient(config as any);
+
+    //   (client as any).rudderstackClient = rudderstack;
+
+    //   const ingestClient = { doIngest: sinon.stub() };
+
+    //   (client as any).ingestClient = ingestClient;
+    //   const timestamp = new Date();
+    //   client.track({
+    //     id: 'id',
+    //     event: Event.INTERACT,
+    //     request: RequestType.REQUEST,
+    //     payload: payload as any,
+    //     sessionid: 'session.id',
+    //     metadata: metadata as any,
+    //     timestamp,
+    //   });
+
+    //   expect(rudderstack.track.callCount).to.eql(1);
+    //   expect(rudderstack.track.getCall(0).args).to.deep.eq([
+    //     {
+    //       userId: 'id',
+    //       event: Event.INTERACT,
+    //       properties: {
+    //         metadata: {
+    //           eventId: Event.INTERACT,
+    //           request: {
+    //             type: RequestType.REQUEST,
+    //             payload: {},
+    //             format: 'request',
+    //             turn_id: undefined,
+    //             timestamp: timestamp.toISOString(),
+    //           },
+    //         },
+    //       },
+    //     },
+    //   ]);
+    // });
+  });
 });


### PR DESCRIPTION
**Fixes or implements VF-1845**

### Brief description. What is this change?

Add the Amazon Pay option in the User Info Step.
This will add payments:autopay_consent permission to the skill manifest to avoid users manually update it every time they upload a skill.

### Implementation details. How do you make this change?

As permission is not needed here and we don't want to generate a card for it on user's end, we will ignore the card generation and only check the permission status = 'GRANTED' 

### Setup information

You want to use the Nico/amazon-pay/VF-1845 branch for creator-app as well as alexa-runtime

### Related PRs

| branch              | PR          |
| ------------------- | ----------- |
| creator-app | [https://github.com/voiceflow/creator-app/tree/Nico/amazon-pay/VF-1845](https://github.com/voiceflow/creator-app/tree/Nico/amazon-pay/VF-1845) |

### Checklist

- [x] title of PR reflects the branch name
- [x] all commits adhere to conventional commits
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [x] all the dependencies are upgraded
