### PR TITLE
ci: skip rebase for dependency bots (VF-2165)

### DIFF
--- a/.github/workflows/rebase.yaml
+++ b/.github/workflows/rebase.yaml
@@ -7,7 +7,7 @@ on:
 jobs:
   rebase-to-master:
     name: Rebase to Master
-    if: github.event.pull_request.draft == false
+    if: github.event.pull_request.draft == false && github.event.pull_request.user.login != 'renovate[bot]' && github.event.pull_request.user.login != 'dependabot[bot]'
     runs-on: ubuntu-latest
     steps:
       - name: Checkout the latest code


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Part or VF-2165**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->

This fixes the comment spam on dependency PRs caused by a bug in the rebase script we are using.

Tests:
- https://github.com/voiceflow/poc-autorebase-gh-action/actions/runs/1418525087
- https://github.com/voiceflow/poc-autorebase-gh-action/actions/runs/1418502067


### Checklist

- [X] title of PR reflects the branch name
- [X] all commits adhere to conventional commits
- [ ] appropriate tests have been written
- [ ] all the dependencies are upgraded

