### PR TITLE
ci: remove unnecessary e2e test (VF-2100)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -154,24 +154,11 @@ workflows:
           context: dev-test
           filters:
             <<: *ignore_staging_filters
-      - vfcommon/test_e2e:
-          <<: *slack-fail-post-step
-          github_username: GITHUB_USERNAME
-          github_token: GITHUB_TOKEN
-          creator_app_commit: DEFAULT_COMMIT
-          vf_service_commit: CIRCLE_SHA1
-          vf_service_name: "alexa-runtime"
-          vf_service_port: "8012"
-          enable: false
-          context: dev-test
-          filters:
-            <<: *ignore_staging_filters
       - vfcommon/release:
           <<: *slack-fail-post-step
           context: dev-test
           requires:
             - e2e-check
-            - vfcommon/test_e2e
             - test
           filters:
             branches:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2100**

### Brief description. What is this change?

Now that this service has been removed from e2e, we do not need to run e2e.
<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->


### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written

