### PR TITLE
feat: use delegation goto (VF-2137)

### DIFF
--- a/lib/constants/flags.ts
+++ b/lib/constants/flags.ts
@@ -16,6 +16,7 @@ export enum Storage {
   STREAM_FINISHED = 'streamFinished',
   STREAM_TEMP = 'streamTemp',
   NO_MATCHES_COUNTER = 'noMatchesCounter',
+  GO_TO_REF = 'goToRef',
 }
 
 export enum Turn {

--- a/lib/constants/flags.ts
+++ b/lib/constants/flags.ts
@@ -31,6 +31,7 @@ export enum Turn {
   TRACE = 'trace',
   DIRECTIVES = 'directives',
   NEW_STACK = 'newStack',
+  DELEGATE = 'delegate',
 }
 
 export enum Frame {

--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -1,5 +1,5 @@
 import * as Ingest from '@voiceflow/general-runtime/build/lib/clients/ingest-client';
-import { Response } from 'ask-sdk-model';
+import { Intent, Response } from 'ask-sdk-model';
 import _isObject from 'lodash/isObject';
 import _mapValues from 'lodash/mapValues';
 
@@ -27,6 +27,11 @@ export const responseGenerator = (utils: typeof utilsObj) => async (runtime: Ale
     .speak(storage.get<string>(S.OUTPUT) ?? '')
     .reprompt((turn.get<string>('reprompt') || storage.get<string>(S.OUTPUT)) ?? '')
     .withShouldEndSession(!!turn.get(T.END));
+
+  const delegate = turn.get<Intent>(T.DELEGATE);
+  if (delegate) {
+    responseBuilder.addDelegateDirective(delegate);
+  }
 
   // eslint-disable-next-line no-restricted-syntax
   for (const handler of utils.responseHandlers) {

--- a/lib/services/runtime/handlers/interaction.ts
+++ b/lib/services/runtime/handlers/interaction.ts
@@ -41,12 +41,14 @@ export const InteractionHandler: HandlerFactory<Node.Interaction.Node, typeof ut
     const index = node.interactions.findIndex((choice) => choice.intent && utils.formatIntentName(choice.intent) === intent.name);
     const choice = node.interactions[index];
     if (choice) {
-      if (choice.goTo?.intentName) {
-        runtime.turn.set<Intent>(T.DELEGATE, { name: choice.goTo.intentName, slots: {}, confirmationStatus: 'NONE' });
-        return node.id;
-      }
       if (choice.mappings && intent.slots) {
         variables.merge(utils.mapSlots({ slots: intent.slots, mappings: choice.mappings }));
+      }
+
+      if (choice.goTo?.intentName) {
+        runtime.storage.set(S.DELEGATION_REF, node.id);
+        runtime.turn.set<Intent>(T.DELEGATE, { name: choice.goTo.intentName, slots: {}, confirmationStatus: 'NONE' });
+        return node.id;
       }
       return node.nextIds[choice.nextIdIndex ?? index] ?? null;
     }

--- a/tests/lib/services/alexa/request/lifecycle/response.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/response.unit.ts
@@ -98,7 +98,11 @@ describe('response lifecycle unit tests', () => {
       getRequest: sinon.stub().returns(request),
       storage: { set: sinon.stub(), get: sinon.stub().returns('speak') },
       turn: {
-        get: sinon.stub().returns(true),
+        get: sinon
+          .stub()
+          .returns(true)
+          .withArgs(T.DELEGATE)
+          .returns('delegation'),
       },
       stack: { isEmpty: sinon.stub().returns(false) },
       variables: { get: sinon.stub().returns(false) },
@@ -115,6 +119,7 @@ describe('response lifecycle unit tests', () => {
     const input = {
       responseBuilder: {
         getResponse: sinon.stub().returns(output),
+        addDelegateDirective: sinon.stub(),
         speak: sinon.stub().returns({ reprompt: sinon.stub().returns({ withShouldEndSession: sinon.stub() }) }),
       },
       requestEnvelope: {
@@ -151,6 +156,7 @@ describe('response lifecycle unit tests', () => {
         },
       ],
     ]);
+    expect(input.responseBuilder.addDelegateDirective.args).to.eql([['delegation']]);
   });
 
   it('response variable', async () => {
@@ -163,7 +169,11 @@ describe('response lifecycle unit tests', () => {
     const runtime = {
       storage: { set: sinon.stub(), get: sinon.stub().returns('speak') },
       turn: {
-        get: sinon.stub().returns(true),
+        get: sinon
+          .stub()
+          .returns(true)
+          .withArgs(T.DELEGATE)
+          .returns(false),
       },
       stack: { isEmpty: sinon.stub().returns(false) },
       variables: { get: sinon.stub().returns(responseVar) },

--- a/tests/lib/services/voiceflow/handlers/interaction.unit.ts
+++ b/tests/lib/services/voiceflow/handlers/interaction.unit.ts
@@ -235,13 +235,6 @@ describe('interaction handler unit tests', async () => {
           const goToIntentName = 'go-to-intent';
 
           const utils = {
-            commandHandler: {
-              canHandle: sinon.stub().returns(true),
-              handle: sinon.stub().returns(output),
-            },
-            noMatchHandler: {
-              canHandle: sinon.stub().returns(false),
-            },
             formatIntentName: sinon.stub().returns(intentName),
           };
 
@@ -260,23 +253,17 @@ describe('interaction handler unit tests', async () => {
           };
           const variables = { foo: 'bar' };
 
-          expect(interactionHandler.handle(block as any, runtime as any, variables as any, null as any)).to.eql(output);
+          expect(interactionHandler.handle(block as any, runtime as any, variables as any, null as any)).to.eql(block.id);
           expect(runtime.turn.set.args).to.eql([
             [
-              T.REQUEST,
+              T.DELEGATE,
               {
-                payload: {
-                  intent: {
-                    name: goToIntentName,
-                    slots: [],
-                  },
-                },
-                type: RequestType.INTENT,
+                name: goToIntentName,
+                slots: {},
+                confirmationStatus: 'NONE',
               },
             ],
           ]);
-          expect(utils.commandHandler.canHandle.callCount).to.eql(1);
-          expect(utils.commandHandler.handle.callCount).to.eql(1);
         });
 
         it('choice with mappings', () => {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2137**

### Brief description. What is this change?

did some more experimentation with the intent delegation:
https://developer.amazon.com/en-US/blogs/alexa/alexa-skills-kit/2019/03/intent-chaining-for-alexa-skill

Checked that it worked for intents with no slots i.e. (AMAZON.HelpIntent) as well as intents with slots defined.

I know @leartgjoni-voiceflow tried last time, but I think what was really bait was the `slots: {}` parameter in the delegate directive. If you leave it undefined, which the type allows, it will crash.

Here's my unscientific expirement:
<img width="808" alt="Screen Shot 2021-11-26 at 2 00 13 PM" src="https://user-images.githubusercontent.com/5643574/143584899-8c616921-f4e0-40f5-9117-6fcf8082783c.png">

<img width="1568" alt="Screen Shot 2021-11-26 at 2 03 55 PM" src="https://user-images.githubusercontent.com/5643574/143585319-cf7c763c-a13d-4ad0-b31a-921b14554003.png">



### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
