### PR TITLE
fix: alexa events (VF-000)

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,22 +3,22 @@ version: 2.1
 parameters:
   npm-repo:
     type: string
-    default: "@voiceflow/alexa-runtime"
+    default: '@voiceflow/alexa-runtime'
   container-image-url:
     type: string
-    default: "168387678261.dkr.ecr.us-east-1.amazonaws.com/alexa"
+    default: '168387678261.dkr.ecr.us-east-1.amazonaws.com/alexa'
   k8s-asset:
     type: string
-    default: "deployment/alexa-runtime"
+    default: 'deployment/alexa-runtime'
   k8s-namespace:
     type: string
-    default: "voiceflow-v1" # This is usually voiceflow-v1
+    default: 'voiceflow-v1' # This is usually voiceflow-v1
   ssh-fingerprint:
     type: string
-    default: "31:42:5a:4e:ee:42:40:e6:77:fc:d4:1b:9f:4e:ca:46"
+    default: '31:42:5a:4e:ee:42:40:e6:77:fc:d4:1b:9f:4e:ca:46'
   track-component:
     type: string
-    default: "alexa-runtime"
+    default: 'alexa-runtime'
 
 # Reusable YAML chunks
 defaults:
@@ -39,12 +39,12 @@ defaults:
       - vfcommon/notify_slack:
           channel: dev_general
           event: fail
-          mentions: "@eng_integrations"
+          mentions: '@eng_integrations'
           template: basic_fail_1
           branch_pattern: master
 
 orbs:
-  vfcommon: voiceflow/common@0.0.251
+  vfcommon: voiceflow/common@0.0.268
   sonarcloud: sonarsource/sonarcloud@1.0.2
 
 jobs:
@@ -54,6 +54,7 @@ jobs:
       - vfcommon/init_e2e_docker:
           checkout: true
           install_node_modules: true
+          avoid_post_install_scripts: false
           github_username: GITHUB_USERNAME
           github_token: GITHUB_TOKEN
           cache_prefix: e2e
@@ -63,14 +64,16 @@ jobs:
           github_username: GITHUB_USERNAME
           github_token: GITHUB_TOKEN
       - vfcommon/check_service_running:
-          port: "8011"
+          port: '8011'
       - vfcommon/check_e2e:
-          port: "8012"
+          port: '8012'
 
   test:
     executor: vfcommon/code-test-executor
     steps:
       - checkout
+      - vfcommon/install_node_modules:
+          avoid_post_install_scripts: false
       - vfcommon/install_node_modules
       - vfcommon/setup_dynamodb
       - vfcommon/lint_report
@@ -97,11 +100,11 @@ jobs:
       image_tag:
         description: The container image tag
         type: string
-        default: ""
+        default: ''
       release_pkg:
         description: The npm package name to be released
         type: string
-        default: ""
+        default: ''
       dockerfile:
         description: Name of the Dockerfile to build
         type: string
@@ -188,5 +191,5 @@ workflows:
           name: build-push-image-e2e
           context: dev-test
           image_repo: << pipeline.parameters.container-image-url >>
-          dockerfile: "Dockerfile.e2e"
-          image_tag: "latest-master-e2e"
+          dockerfile: 'Dockerfile.e2e'
+          image_tag: 'latest-master-e2e'

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,13 +5,17 @@ ARG NPM_TOKEN
 WORKDIR /target
 COPY ./ ./
 
+RUN apk add --no-cache python3 make g++
+
 RUN echo $NPM_TOKEN > .npmrc && \
-  yarn install --ignore-scripts && \
+  yarn install && \
   yarn build && \
   rm -rf build/node_modules && \
   rm -f .npmrc
 
 FROM node:16-alpine
+
+RUN apk add --no-cache dumb-init python3 make g++
 
 ARG NPM_TOKEN
 
@@ -31,7 +35,7 @@ WORKDIR /usr/src/app
 COPY --from=build /target/build ./
 
 RUN echo $NPM_TOKEN > .npmrc && \
-  yarn install --production --ignore-scripts && \
+  yarn install --production && \
   rm -f .npmrc && \
   yarn cache clean
 

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,6 +1,6 @@
 FROM node:16-alpine
 
-RUN apk add --no-cache dumb-init ca-certificates
+RUN apk add --no-cache dumb-init ca-certificates python3 make g++
 
 ARG NPM_TOKEN
 
@@ -19,7 +19,7 @@ WORKDIR /target
 COPY ./ ./
 
 RUN echo $NPM_TOKEN > .npmrc && \
-  yarn install --ignore-scripts && \
+  yarn install && \
   rm -f .npmrc && \
   yarn cache clean
 

--- a/lib/services/alexa/request/event/index.ts
+++ b/lib/services/alexa/request/event/index.ts
@@ -2,12 +2,13 @@ import { RequestHandler } from 'ask-sdk';
 
 import { AlexaHandlerInput } from '../../types';
 import IntentHandler from '../intent';
-import { buildRuntime } from '../lifecycle';
+import { buildRuntime, initialize } from '../lifecycle';
 import handleEvent, { getEvent } from './runtime';
 
 const utilsObj = {
-  buildRuntime,
   getEvent,
+  initialize,
+  buildRuntime,
   IntentHandler,
 };
 
@@ -15,7 +16,15 @@ export const EventHandlerGenerator = (utils: typeof utilsObj): RequestHandler =>
   async canHandle(input: AlexaHandlerInput): Promise<boolean> {
     const runtime = await utils.buildRuntime(input);
 
-    return !!utils.getEvent(runtime);
+    if (runtime.stack.getSize() === 0) {
+      await utils.initialize(runtime, input);
+      await runtime.hydrateStack();
+    }
+
+    const canHandle = !!utils.getEvent(runtime);
+    if (canHandle) input.attributesManager.setPersistentAttributes(runtime.getRawState());
+
+    return canHandle;
   },
   handle: async (input: AlexaHandlerInput) => {
     // based on the event, modify the runtime

--- a/lib/services/alexa/request/sessionEnded.ts
+++ b/lib/services/alexa/request/sessionEnded.ts
@@ -12,6 +12,7 @@ import { updateRuntime } from '../utils';
 
 export enum Request {
   SESSION_ENDED = 'SessionEndedRequest',
+  SYSTEM_EXCEPTION = 'System.ExceptionEncountered',
 }
 
 export enum ErrorType {
@@ -32,7 +33,7 @@ export const SessionEndedHandlerGenerator = (utils: typeof utilsObj): RequestHan
   canHandle(input: AlexaHandlerInput): boolean {
     const { type } = input.requestEnvelope.request;
 
-    return type === Request.SESSION_ENDED;
+    return type === Request.SESSION_ENDED || type === Request.SYSTEM_EXCEPTION;
   },
   async handle(input: AlexaHandlerInput) {
     const request = input.requestEnvelope.request as SessionEndedRequest;

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
     "@voiceflow/base-types": "2.4.1",
     "@voiceflow/body-parser": "1.21.0",
     "@voiceflow/common": "6.9.3",
-    "@voiceflow/general-runtime": "1.70.0",
+    "@voiceflow/general-runtime": "1.74.0",
     "@voiceflow/general-types": "3.2.4",
     "@voiceflow/logger": "1.6.1",
     "@voiceflow/metrics": "1.1.0",

--- a/tests/lib/services/alexa/request/event/index.unit.ts
+++ b/tests/lib/services/alexa/request/event/index.unit.ts
@@ -12,19 +12,53 @@ describe('alexa request event unit tests', () => {
   describe('EventHandlerGenerator', () => {
     describe('canHandle', () => {
       it('works with truthy getEvent return value', async () => {
-        const utils = { getEvent: sinon.stub().returns('abc'), buildRuntime: sinon.stub().resolves('buildRuntime-val') };
+        const runtime = { stack: { getSize: sinon.stub().returns(1) }, getRawState: sinon.stub().returns('getRawState-val') };
+        const input = { attributesManager: { setPersistentAttributes: sinon.stub() } };
+        const utils = {
+          getEvent: sinon.stub().returns('abc'),
+          buildRuntime: sinon.stub().resolves(runtime),
+          attributesManager: { setPersistentAttributes: sinon.stub() },
+        };
 
-        expect(await EventHandlerGenerator(utils as any).canHandle('input-val' as any)).to.eql(true);
-        expect(utils.getEvent.args).to.eql([['buildRuntime-val']]);
-        expect(utils.buildRuntime.args).to.eql([['input-val']]);
+        expect(await EventHandlerGenerator(utils as any).canHandle(input as any)).to.eql(true);
+        expect(utils.getEvent.args).to.eql([[runtime]]);
+        expect(utils.buildRuntime.args).to.eql([[input]]);
+        expect(input.attributesManager.setPersistentAttributes.args).to.eql([['getRawState-val']]);
       });
 
       it('works with falsy getEvent return value', async () => {
-        const utils = { getEvent: sinon.stub().returns(''), buildRuntime: sinon.stub().resolves('buildRuntime-val') };
+        const runtime = { stack: { getSize: sinon.stub().returns(1) } };
+        const input = { attributesManager: { setPersistentAttributes: sinon.stub() } };
+        const utils = {
+          getEvent: sinon.stub().returns(''),
+          buildRuntime: sinon.stub().resolves(runtime),
+          attributesManager: { setPersistentAttributes: sinon.stub() },
+        };
 
-        expect(await EventHandlerGenerator(utils as any).canHandle('input-val' as any)).to.eql(false);
-        expect(utils.getEvent.args).to.eql([['buildRuntime-val']]);
-        expect(utils.buildRuntime.args).to.eql([['input-val']]);
+        expect(await EventHandlerGenerator(utils as any).canHandle(input as any)).to.eql(false);
+        expect(utils.getEvent.args).to.eql([[runtime]]);
+        expect(utils.buildRuntime.args).to.eql([[input]]);
+      });
+
+      it('initialize and hydrates', async () => {
+        const runtime = {
+          stack: { getSize: sinon.stub().returns(0) },
+          hydrateStack: sinon.stub(),
+          getRawState: sinon.stub().returns('getRawState-val'),
+        };
+        const input = { attributesManager: { setPersistentAttributes: sinon.stub() } };
+        const utils = {
+          getEvent: sinon.stub().returns('abc'),
+          buildRuntime: sinon.stub().resolves(runtime),
+          initialize: sinon.stub(),
+        };
+
+        expect(await EventHandlerGenerator(utils as any).canHandle(input as any)).to.eql(true);
+        expect(runtime.hydrateStack.callCount).to.eql(1);
+        expect(utils.initialize.args).to.eql([[runtime, input]]);
+        expect(utils.getEvent.args).to.eql([[runtime]]);
+        expect(utils.buildRuntime.args).to.eql([[input]]);
+        expect(input.attributesManager.setPersistentAttributes.args).to.eql([['getRawState-val']]);
       });
     });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1120,12 +1120,12 @@
     "@voiceflow/voice-types" "^2.1.4"
     ask-smapi-model "1.14.0"
 
-"@voiceflow/api-sdk@3.3.0":
-  version "3.3.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-3.3.0.tgz#682a4aea51cabe9ba44c630a4eae056d3d45512d"
-  integrity sha512-uB0Ll6PgdTPHgDJgclwQHEv4NPGxW4T0qKliZwQqQo8yx8pjmhfUANzlNgk93XkxM5rM4RZFYaPg7B1R8xVYcg==
+"@voiceflow/api-sdk@3.3.5":
+  version "3.3.5"
+  resolved "https://registry.yarnpkg.com/@voiceflow/api-sdk/-/api-sdk-3.3.5.tgz#ef139faa8cbc4714d2a69f9f9fd51a9cd436515d"
+  integrity sha512-8WYi18gmph2sIWuEvmWsV36BE8Y9h87FI7cMddTO2oIdnyjsgU6uRXbNf2WnSLxTZWDLaU12RhQwFIVbTwD/IQ==
   dependencies:
-    "@voiceflow/base-types" "^2.3.0"
+    "@voiceflow/base-types" "^2.4.2"
     "@voiceflow/common" "^7.10.0"
     axios "^0.21.1"
     jwt-decode "^3.1.2"
@@ -1178,17 +1178,24 @@
     rate-limiter-flexible "^2.2.2"
     sinon "^10.0.0"
 
-"@voiceflow/base-types@2.3.0", "@voiceflow/base-types@^2.3.0":
-  version "2.3.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.3.0.tgz#447a9d49f1cdc6422c7e7d6fc54fc9d47bf899ea"
-  integrity sha512-G2Wcqwl+t6tNSICB6T1HtRgEyOFu2qf+Nvp/WJkbXVYM5sAbHKI30241Yf6LNNH76bFqplE07ucxnsJwAv+NuA==
-  dependencies:
-    slate "^0.63.0"
-
 "@voiceflow/base-types@2.4.1", "@voiceflow/base-types@^2.4.1":
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.4.1.tgz#8300d9c43d51865a6c77c0c9af47a8764685e6b2"
   integrity sha512-Qh8QzsS6gCZIDhIYAMw2CvhJj6a07cv7wp1BLZWaMz5EDLAwjIHo3rBh96C1zdHMXhKSBjOWzB6extuYDi2hFA==
+  dependencies:
+    slate "^0.63.0"
+
+"@voiceflow/base-types@2.4.2":
+  version "2.4.2"
+  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.4.2.tgz#ff8f4c79e2df53368c39ae0607b0c63dd813c236"
+  integrity sha512-Bhz5yGSlZUu7Obnba1FNkgFcKajoSjOXDeQeDR2avmOT90PmTxa9bjBzB2cvn+orGeCCKVNNZAGVCxp5FGWdNA==
+  dependencies:
+    slate "^0.63.0"
+
+"@voiceflow/base-types@^2.4.2", "@voiceflow/base-types@^2.5.3":
+  version "2.5.3"
+  resolved "https://registry.yarnpkg.com/@voiceflow/base-types/-/base-types-2.5.3.tgz#40016993e38e7d157b2114ac68c9f2b230002d23"
+  integrity sha512-ju79XqbdUsqFiufr/9VzT4lzQgatvWl654sx/eTemiCXezjXyNwGsncHEsQy7ZdRn8ncYfRTvt3MANARtFwftA==
   dependencies:
     slate "^0.63.0"
 
@@ -1209,12 +1216,12 @@
     secure-json-parse "^2.4.0"
     type-is "~1.6.18"
 
-"@voiceflow/chat-types@2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/chat-types/-/chat-types-2.1.0.tgz#434c465f42b83dabad41cdc8b99e6dbec1038b00"
-  integrity sha512-YG6AoRXnhv5KzEbHOluwBqTkt2F3BvBhUY2zPQ/tCoOiXtIzoNlKtzo7uZSgvUTRoNdFQeh/Mb32JsxkL490+A==
+"@voiceflow/chat-types@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@voiceflow/chat-types/-/chat-types-2.1.5.tgz#4a1b9776ef1c635f348e03518ace9bac771721bc"
+  integrity sha512-SLosFbQ/OJQnS4+8GzAGeHs+1Js/SLtOOqXjCIP+9YZTuo8XhNjnNkqqEhPv7qaHt/Uu1C8ssD6VYjZcZA42Zw==
   dependencies:
-    "@voiceflow/base-types" "^2.3.0"
+    "@voiceflow/base-types" "^2.4.2"
 
 "@voiceflow/commitlint-config@1.1.1":
   version "1.1.1"
@@ -1283,24 +1290,24 @@
     eslint-plugin-xss "^0.1.9"
     eslint-plugin-you-dont-need-lodash-underscore "^6.12.0"
 
-"@voiceflow/general-runtime@1.70.0":
-  version "1.70.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-runtime/-/general-runtime-1.70.0.tgz#39f3454351c91cd000028fb1be917323a48dc64d"
-  integrity sha512-L03UcuHdxQAw8vZaPbUt99AqX4CSKIzVDJM0W1dHK7olYJoyElGLlEE3AeszhjbnDlC3dUt8nC324Quq5q31Mw==
+"@voiceflow/general-runtime@1.74.0":
+  version "1.74.0"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-runtime/-/general-runtime-1.74.0.tgz#2d0dde695378c228e5bc645648072a0d58f55ced"
+  integrity sha512-LmIyRq8V8SRoPvEwk1cDCsLOF4Q1qQT15BkDwiY9rGMBjfHjX2F4bsQFQ8NZZHocN1XB/HGE+p0EIzWgmuwKJw==
   dependencies:
     "@types/mathjs" "^6.0.4"
     "@types/workerpool" "^5.0.1"
-    "@voiceflow/api-sdk" "3.3.0"
+    "@voiceflow/api-sdk" "3.3.5"
     "@voiceflow/backend-utils" "3.3.0"
-    "@voiceflow/base-types" "2.3.0"
+    "@voiceflow/base-types" "2.4.2"
     "@voiceflow/body-parser" "^1.21.0"
-    "@voiceflow/chat-types" "2.1.0"
+    "@voiceflow/chat-types" "2.1.5"
     "@voiceflow/common" "6.7.1"
-    "@voiceflow/general-types" "3.2.0"
+    "@voiceflow/general-types" "3.2.5"
     "@voiceflow/logger" "^1.6.0"
     "@voiceflow/natural-language-commander" "^0.5.1"
     "@voiceflow/verror" "^1.1.0"
-    "@voiceflow/voice-types" "2.1.0"
+    "@voiceflow/voice-types" "2.1.5"
     ajv "6.12.2"
     axios "^0.21.1"
     bluebird "^3.7.2"
@@ -1319,6 +1326,7 @@
     html-parse-stringify "^1.0.3"
     immer "^9.0.6"
     ioredis "^4.22.0"
+    isolated-vm "^4.3.6"
     lodash "^4.17.21"
     mathjs "^6.5.0"
     moize "^6.1.0"
@@ -1328,17 +1336,9 @@
     safe-json-stringify "^1.2.0"
     slate "^0.65.3"
     talisman "^1.1.3"
-    vm2 "^3.9.2"
+    vm2 "^3.9.5"
     words-to-numbers "^1.5.1"
     workerpool "^5.0.4"
-
-"@voiceflow/general-types@3.2.0":
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-3.2.0.tgz#d625f8861b018177a5101c2d6186719373bfd28c"
-  integrity sha512-mqE/QxhJXy7A1qIdTNBOt8FSiOOZZziKJfUeqvAGsyYRvqpopA4Bmcto64WJv6ckyFKgvLjIptoe+YIdeVvalA==
-  dependencies:
-    "@voiceflow/base-types" "^2.3.0"
-    "@voiceflow/voice-types" "^2.1.0"
 
 "@voiceflow/general-types@3.2.4", "@voiceflow/general-types@^3.2.4":
   version "3.2.4"
@@ -1347,6 +1347,14 @@
   dependencies:
     "@voiceflow/base-types" "^2.4.1"
     "@voiceflow/voice-types" "^2.1.4"
+
+"@voiceflow/general-types@3.2.5":
+  version "3.2.5"
+  resolved "https://registry.yarnpkg.com/@voiceflow/general-types/-/general-types-3.2.5.tgz#20bb5c4245f6d1a98292466cb608873ebaeb3a89"
+  integrity sha512-yeZzjy80bajnAHPfZcAq+Q0xxXA/VfTSFzEZ67zII4lMuVRvymhiM8CF2oRtEW95ExyzrbEso4fdfce2eNBxqg==
+  dependencies:
+    "@voiceflow/base-types" "^2.4.2"
+    "@voiceflow/voice-types" "^2.1.5"
 
 "@voiceflow/git-branch-check@1.2.1":
   version "1.2.1"
@@ -1450,19 +1458,26 @@
   dependencies:
     http-status "^1.3.2"
 
-"@voiceflow/voice-types@2.1.0", "@voiceflow/voice-types@^2.1.0":
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/@voiceflow/voice-types/-/voice-types-2.1.0.tgz#a87313a234fb954345ec446ab591ef33f770c883"
-  integrity sha512-DYiMPvbWRcfYR5VUTqeZ3bMaGhTVMBifWxPeFc2vPK/tywUK+HmccnXipAwBFujRl17mC6P6icngfbzCmWJcug==
-  dependencies:
-    "@voiceflow/base-types" "^2.3.0"
-
 "@voiceflow/voice-types@2.1.4", "@voiceflow/voice-types@^2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@voiceflow/voice-types/-/voice-types-2.1.4.tgz#727c60ef16548ed1f8fbe35fa4625e72705b2416"
   integrity sha512-wSesrq+nM/OouAjeKP2vZ/Nzl+v2ZEGe60SZVt7ZHzf7JC6VaZ6EZZBq+6TulNsjhG5+ywftr7RgFKWwHgEF/w==
   dependencies:
     "@voiceflow/base-types" "^2.4.1"
+
+"@voiceflow/voice-types@2.1.5":
+  version "2.1.5"
+  resolved "https://registry.yarnpkg.com/@voiceflow/voice-types/-/voice-types-2.1.5.tgz#a675ee86fac8f3d4cc0f727702653420262c4c20"
+  integrity sha512-OsuZUsPA44ZjaTCrlCtsyeVY4YpDUp5Z1Mwif7Ooq60rqXa3ok4W9nVGq0AOlEGtqJqucLgzkt7YFqF1fCMGCw==
+  dependencies:
+    "@voiceflow/base-types" "^2.4.2"
+
+"@voiceflow/voice-types@^2.1.5":
+  version "2.1.9"
+  resolved "https://registry.yarnpkg.com/@voiceflow/voice-types/-/voice-types-2.1.9.tgz#d7989a0347adb613a32a6a8a82f92d3b10109e6e"
+  integrity sha512-Cpi5kEaRCTQHUdL7QSPduq/q63aduAr0PjsO0IDpz/FITH5jmXCx3inrIBCAC2vEuBw8OW9sChWu174oy2CLKg==
+  dependencies:
+    "@voiceflow/base-types" "^2.5.3"
 
 "@zerollup/ts-helpers@^1.7.18":
   version "1.7.18"
@@ -5363,6 +5378,11 @@ isobject@^3.0.0, isobject@^3.0.1:
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
 
+isolated-vm@^4.3.6:
+  version "4.3.6"
+  resolved "https://registry.yarnpkg.com/isolated-vm/-/isolated-vm-4.3.6.tgz#443672194c96fc077f219d6c115d50b1706d9611"
+  integrity sha512-YvioBOU6wUNSTOWGgX/pDPLF9/WaSLsX8GqL7RlFCKzBXTXzyfG+T4JNIRNEiowtZk5H5ekJSUFqbx2QHSpJDQ==
+
 isstream@~0.1.2:
   version "0.1.2"
   resolved "https://registry.yarnpkg.com/isstream/-/isstream-0.1.2.tgz#47e63f7af55afa6f92e1500e690eb8b8529c099a"
@@ -9062,7 +9082,7 @@ verror@1.10.0:
     core-util-is "1.0.2"
     extsprintf "^1.2.0"
 
-vm2@^3.9.2:
+vm2@^3.9.5:
   version "3.9.5"
   resolved "https://registry.yarnpkg.com/vm2/-/vm2-3.9.5.tgz#5288044860b4bbace443101fcd3bddb2a0aa2496"
   integrity sha512-LuCAHZN75H9tdrAiLFf030oW7nJV5xwNMuk1ymOZwopmuK3d2H4L1Kv4+GFHgarKiLfXXLFU+7LDABHnwOkWng==


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?

All that changed is this:
```
    if (runtime.stack.getSize() === 0) {
      await utils.initialize(runtime, input);
      await runtime.hydrateStack();
    }

    const canHandle = !!utils.getEvent(runtime);
    if (canHandle) input.attributesManager.setPersistentAttributes(runtime.getRawState());

    return canHandle;
```

What's happening is if an Alexa event comes in and the Voiceflow stack is empty, now we insert the root/base flows along with all their commands so these commands will catch:
![Screen Shot 2021-12-16 at 3 22 03 PM](https://user-images.githubusercontent.com/5643574/146443706-ed2e67e8-d367-4a8f-bcc2-40174e71e319.png)


### Implementation details. How do you make this change?

<!-- Explain the way/approach you follow to make this change more deeply in order to help your teammates to understand much easier this change -->

### Setup information

<!-- Notes regarding local environment. These should note any new configurations, new environment variables, etc. -->


### Deployment Notes

<!-- Notes regarding deployment the contained body of work. These should note any db migrations, etc. -->

### Related PRs

<!-- List related PRs against other branches -->

| branch              | PR          |
| ------------------- | ----------- |
| other_pr_production | [link](url) |
| other_pr_master     | [link](url) |

### Checklist

- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
