### PR TITLE
fix: disable output with audioplayer events (VF-2475)

### DIFF
--- a/lib/services/alexa/constants.ts
+++ b/lib/services/alexa/constants.ts
@@ -1,3 +1,13 @@
+import { Request } from './types';
+
 export const SEND_REQUEST_DIRECTIVE = 'Connections.SendRequest';
 
 export const DirectivesInvalidWithAudioPlayer = new Set([SEND_REQUEST_DIRECTIVE]);
+
+export const speakNotAllowedRequestTypes = new Set<string>([
+  Request.AUDIO_PLAYER_PLAYBACK_FAILED,
+  Request.AUDIO_PLAYER_PLAYBACK_FINISHED,
+  Request.AUDIO_PLAYER_PLAYBACK_NEARLY_FINISHED,
+  Request.AUDIO_PLAYER_PLAYBACK_STARTED,
+  Request.AUDIO_PLAYER_PLAYBACK_STOPPED,
+]);

--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -8,7 +8,7 @@ import { responseHandlers } from '@/lib/services/runtime/handlers';
 import { AlexaRuntime } from '@/lib/services/runtime/types';
 import log from '@/logger';
 
-import { DirectivesInvalidWithAudioPlayer } from '../../constants';
+import { DirectivesInvalidWithAudioPlayer, speakNotAllowedRequestTypes } from '../../constants';
 import { AlexaHandlerInput, Request } from '../../types';
 
 const utilsObj = {
@@ -17,14 +17,21 @@ const utilsObj = {
 
 export const responseGenerator = (utils: typeof utilsObj) => async (runtime: AlexaRuntime, input: AlexaHandlerInput): Promise<Response> => {
   const { storage, turn, variables } = runtime;
-  const { responseBuilder, attributesManager } = input;
+  const {
+    responseBuilder,
+    attributesManager,
+    requestEnvelope: { request },
+  } = input;
 
   if (runtime.stack.isEmpty()) {
     turn.set(T.END, true);
   }
 
-  responseBuilder.speak(storage.get<string>(S.OUTPUT) ?? '');
-  responseBuilder.reprompt((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? '');
+  if (!speakNotAllowedRequestTypes.has(request.type)) {
+    responseBuilder.speak(storage.get<string>(S.OUTPUT) ?? '');
+    responseBuilder.reprompt((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? '');
+  }
+
   responseBuilder.withShouldEndSession(!!turn.get(T.END));
 
   // eslint-disable-next-line no-restricted-syntax

--- a/lib/services/alexa/types.ts
+++ b/lib/services/alexa/types.ts
@@ -18,6 +18,11 @@ export enum Request {
   INTENT = 'IntentRequest',
   AUDIO_PLAYER = 'AudioPlayer.',
   SKILL_EVENT_ROOT = 'AlexaSkillEvent.',
-  PERMISSION_ACCEPTED = 'AlexaSkillEvent.SkillPermissionAccepted',
   PERMISSION_CHANGED = 'AlexaSkillEvent.SkillPermissionChanged',
+  PERMISSION_ACCEPTED = 'AlexaSkillEvent.SkillPermissionAccepted',
+  AUDIO_PLAYER_PLAYBACK_FAILED = 'AudioPlayer.PlaybackFailed',
+  AUDIO_PLAYER_PLAYBACK_STARTED = 'AudioPlayer.PlaybackStarted',
+  AUDIO_PLAYER_PLAYBACK_STOPPED = 'AudioPlayer.PlaybackStopped',
+  AUDIO_PLAYER_PLAYBACK_FINISHED = 'AudioPlayer.PlaybackFinished',
+  AUDIO_PLAYER_PLAYBACK_NEARLY_FINISHED = 'AudioPlayer.PlaybackNearlyFinished',
 }


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2475**

### Brief description. What is this change?
Basically Nico sums it up here nicely:
![Screen Shot 2022-01-21 at 5 36 21 PM](https://user-images.githubusercontent.com/5643574/150609177-ee7a535e-a606-4dcf-a536-64bc57b3db4e.png)

You can not send an output or reprompt when these requests are given. Even if the user doesn't have a speak block we were still throwing these in.

Amazon docs:
https://developer.amazon.com/en-US/docs/alexa/custom-skills/audioplayer-interface-reference.html#valid-response-types-2

https://developer.amazon.com/en-US/docs/alexa/custom-skills/audioplayer-interface-reference.html#valid-response-types-2
