### PR TITLE
[Merged by Bors] - fix: update vscode eslint config (VF-2441)

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -4,6 +4,11 @@
   "eslint.format.enable": true,
   "eslint.lintTask.enable": true,
   "eslint.packageManager": "yarn",
+  "eslint.rules.customizations": [
+    { "rule": "no-use-before-define", "severity": "off" },
+    { "rule": "prettier/prettier", "severity": "off" },
+    { "rule": "simple-import-sort/imports", "severity": "off" }
+  ],
   "javascript.updateImportsOnFileMove.enabled": "always",
   "editor.defaultFormatter": "esbenp.prettier-vscode",
   "[json]": {


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2441**

### Brief description. What is this change?

Update vscode config to ignore auto-fixable rules when editing a file.

This way, we don't get bothered with a bunch of warnings and errors, which will be auto-fixed on pre-commit