### PR TITLE
feat: add verifier for user ID (VF-2849)

### DIFF
--- a/lib/clients/index.ts
+++ b/lib/clients/index.ts
@@ -14,6 +14,7 @@ import MongoDB from './mongodb';
 import Multimodal, { MultimodalType } from './multimodal';
 import PostgresDB from './postgres';
 import Static, { StaticType } from './static';
+import { AlexaUserIDVerifier } from './verifiers';
 
 export interface ClientMap extends StaticType {
   dynamo: DynamoType;
@@ -42,7 +43,7 @@ const buildClients = (config: Config): ClientMap => {
   const mongo = MongoPersistenceAdapter.enabled(config) ? new MongoDB(config) : null;
   const pg = PostgresPersistenceAdapter.enabled(config) ? new PostgresDB(config) : null;
   const analyticsClient = Analytics({ config, dataAPI });
-  const alexaVerifiers = [new SkillRequestSignatureVerifier(), new TimestampVerifier()];
+  const alexaVerifiers = [new AlexaUserIDVerifier(), new SkillRequestSignatureVerifier(), new TimestampVerifier()];
 
   return {
     ...Static,

--- a/lib/clients/verifiers/index.ts
+++ b/lib/clients/verifiers/index.ts
@@ -1,0 +1,1 @@
+export * from './userIDVerifier';

--- a/lib/clients/verifiers/userIDVerifier.ts
+++ b/lib/clients/verifiers/userIDVerifier.ts
@@ -1,0 +1,13 @@
+import { createAskSdkError } from 'ask-sdk';
+import { Verifier } from 'ask-sdk-express-adapter';
+import { RequestEnvelope } from 'ask-sdk-model';
+
+// eslint-disable-next-line import/prefer-default-export
+export class AlexaUserIDVerifier implements Verifier {
+  async verify(requestEnvelope: string): Promise<void> {
+    const requestEnvelopeJson: RequestEnvelope = JSON.parse(requestEnvelope);
+    if (requestEnvelopeJson?.context?.System?.user?.userId == null) {
+      throw createAskSdkError(this.constructor.name, 'User ID not found in request envelope');
+    }
+  }
+}

--- a/lib/middlewares/alexa.ts
+++ b/lib/middlewares/alexa.ts
@@ -19,7 +19,7 @@ class AlexaMiddleware extends AbstractMiddleware {
         req.body = JSON.parse(req.body);
       } catch (error) {
         log.debug(`[http] [${this.constructor.name}] failed to parse JSON from body ${log.vars({ body: req.body, error })}`);
-        return res.status(400).json({ status: 'failure', reason: error });
+        return res.status(400).json({ status: 'failure', reason: error.message });
       }
 
       if (this.config.NODE_ENV === 'test') {
@@ -36,7 +36,7 @@ class AlexaMiddleware extends AbstractMiddleware {
         );
       } catch (error) {
         log.debug(`[http] [${this.constructor.name}] request verification failed ${log.vars({ body: req.body, error })}`);
-        return res.status(400).json({ status: 'failure', reason: error });
+        return res.status(400).json({ status: 'failure', reason: error.message });
       }
 
       return next();


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2849**

### Brief description. What is this change?

Instead of throwing an error during skill execution when the request body is missing the user ID, we can add a `Verifier` to check that the body contains the request body.

This will cause a 400 error to be returned, instead of a 500.