### PR TITLE
[Merged by Bors] - feat: can fulfill intent handler (VF-2849)

### DIFF
--- a/lib/middlewares/alexa.ts
+++ b/lib/middlewares/alexa.ts
@@ -19,7 +19,7 @@ class AlexaMiddleware extends AbstractMiddleware {
         req.body = JSON.parse(req.body);
       } catch (error) {
         log.debug(`[http] [${this.constructor.name}] failed to parse JSON from body ${log.vars({ body: req.body, error })}`);
-        return res.status(400).json({ status: 'failure', reason: error });
+        return res.status(400).json({ status: 'failure', reason: error.message });
       }
 
       if (this.config.NODE_ENV === 'test') {
@@ -36,7 +36,7 @@ class AlexaMiddleware extends AbstractMiddleware {
         );
       } catch (error) {
         log.debug(`[http] [${this.constructor.name}] request verification failed ${log.vars({ body: req.body, error })}`);
-        return res.status(400).json({ status: 'failure', reason: error });
+        return res.status(400).json({ status: 'failure', reason: error.message });
       }
 
       return next();

--- a/lib/services/alexa/index.ts
+++ b/lib/services/alexa/index.ts
@@ -13,6 +13,7 @@ import {
   APLUserEventHandler,
   AudioPlayerEventHandler,
   CancelPurchaseHandler,
+  CanFulfillIntentHandler,
   ErrorHandlerGenerator,
   EventHandler,
   IntentHandler,
@@ -54,6 +55,7 @@ const utilsObj = {
     PlaybackControllerHandler,
     PurchaseHandler,
     SessionEndedHandler,
+    CanFulfillIntentHandler,
   },
   interceptors: { RequestInterceptorGenerator, ResponseInterceptor },
   builder: SkillBuilders,
@@ -90,6 +92,7 @@ const AlexaManager = (services: Services, config: Config, utils = utilsObj) => {
     skill: builder
       .custom()
       .addRequestHandlers(
+        handlers.CanFulfillIntentHandler,
         handlers.EventHandler,
         handlers.LaunchHandler,
         handlers.IntentHandler,

--- a/lib/services/alexa/request/canFulfill.ts
+++ b/lib/services/alexa/request/canFulfill.ts
@@ -18,14 +18,18 @@ export const CanFulfillIntentHandler = (): RequestHandler => ({
 
     const version = await input.context.api.getVersion(input.context.versionID);
 
-    const hasIntent = !!version.prototype?.model?.intents?.find?.((_intent) => _intent.name === intent.name);
+    const existingIntent = version.prototype?.model?.intents?.find?.((_intent) => _intent.name === intent.name);
 
     const hasSlots = Object.keys(intent.slots ?? {}).map((slotName) => {
-      const hasSlot = !!version.prototype?.model?.slots?.find?.((_slot) => _slot.name === slotName);
+      const hasSlot =
+        !!existingIntent &&
+        !!version.prototype?.model?.slots?.find?.(
+          (_slot) => existingIntent.slots?.find((intentSlot) => _slot.key === intentSlot.id) && _slot.name === slotName
+        );
       return [slotName, hasSlot] as const;
     });
 
-    const canFulfill = hasIntent && hasSlots.every(([, hasSlot]) => hasSlot);
+    const canFulfill = !!existingIntent && hasSlots.every(([, hasSlot]) => hasSlot);
 
     const response = input.responseBuilder.withCanFulfillIntent({
       canFulfill: canFulfill ? 'YES' : 'NO',

--- a/lib/services/alexa/request/canFulfill.ts
+++ b/lib/services/alexa/request/canFulfill.ts
@@ -1,0 +1,47 @@
+import { RequestHandler } from 'ask-sdk';
+import { canfulfill } from 'ask-sdk-model';
+
+import { AlexaHandlerInput } from '../types';
+
+export enum Request {
+  CAN_FULFILL_INTENT = 'CanFulfillIntentRequest',
+}
+
+export const CanFulfillIntentHandler = (): RequestHandler => ({
+  canHandle(input: AlexaHandlerInput): boolean {
+    const { type } = input.requestEnvelope.request;
+
+    return type === Request.CAN_FULFILL_INTENT;
+  },
+  async handle(input: AlexaHandlerInput) {
+    const { intent } = input.requestEnvelope.request as canfulfill.CanFulfillIntentRequest;
+
+    const version = await input.context.api.getVersion(input.context.versionID);
+
+    const hasIntent = !!version.prototype?.model?.intents?.find?.((_intent) => _intent.name === intent.name);
+
+    const hasSlots = Object.keys(intent.slots ?? {}).map((slotName) => {
+      const hasSlot = !!version.prototype?.model?.slots?.find?.((_slot) => _slot.name === slotName);
+      return [slotName, hasSlot] as const;
+    });
+
+    const canFulfill = hasIntent && hasSlots.every(([, hasSlot]) => hasSlot);
+
+    const response = input.responseBuilder.withCanFulfillIntent({
+      canFulfill: canFulfill ? 'YES' : 'NO',
+      slots: Object.fromEntries(
+        hasSlots.map(([slotName, hasSlot]) => [
+          slotName,
+          {
+            canUnderstand: hasSlot ? 'YES' : 'NO',
+            canFulfill: hasSlot ? 'YES' : 'NO',
+          },
+        ])
+      ),
+    });
+
+    return response.getResponse();
+  },
+});
+
+export default CanFulfillIntentHandler();

--- a/lib/services/alexa/request/canFulfill.ts
+++ b/lib/services/alexa/request/canFulfill.ts
@@ -18,12 +18,12 @@ export const CanFulfillIntentHandler = (): RequestHandler => ({
 
     const version = await input.context.api.getVersion(input.context.versionID);
 
-    const existingIntent = version.prototype?.model?.intents?.find?.((_intent) => _intent.name === intent.name);
+    const existingIntent = version.platformData?.intents?.find?.((_intent) => _intent.name === intent.name);
 
     const hasSlots = Object.keys(intent.slots ?? {}).map((slotName) => {
       const hasSlot =
         !!existingIntent &&
-        !!version.prototype?.model?.slots?.find?.(
+        !!version.platformData?.slots?.find?.(
           (_slot) => existingIntent.slots?.find((intentSlot) => _slot.key === intentSlot.id) && _slot.name === slotName
         );
       return [slotName, hasSlot] as const;

--- a/lib/services/alexa/request/index.ts
+++ b/lib/services/alexa/request/index.ts
@@ -1,6 +1,7 @@
 export { default as APLUserEventHandler } from './aplUserEvent';
 export { default as AudioPlayerEventHandler } from './audioPlayerEvent';
 export { default as CancelPurchaseHandler } from './cancelPurchase';
+export { default as CanFulfillIntentHandler } from './canFulfill';
 export { default as ErrorHandlerGenerator } from './error';
 export { default as EventHandler } from './event';
 export { default as IntentHandler } from './intent';

--- a/lib/services/alexa/request/launch.ts
+++ b/lib/services/alexa/request/launch.ts
@@ -5,7 +5,6 @@ import { buildResponse, buildRuntime, initialize, update } from './lifecycle';
 
 export enum Request {
   LAUNCH = 'LaunchRequest',
-  CAN_FULFILL_INTENT = 'CanFulfillIntentRequest',
 }
 
 const utilsObj = {
@@ -19,7 +18,7 @@ export const LaunchHandlerGenerator = (utils: typeof utilsObj): RequestHandler =
   canHandle(input: AlexaHandlerInput): boolean {
     const { type } = input.requestEnvelope.request;
 
-    return type === Request.LAUNCH || type === Request.CAN_FULFILL_INTENT;
+    return type === Request.LAUNCH;
   },
   async handle(input: AlexaHandlerInput) {
     const runtime = await utils.buildRuntime(input);

--- a/tests/lib/services/alexa/index.unit.ts
+++ b/tests/lib/services/alexa/index.unit.ts
@@ -21,6 +21,7 @@ describe('alexa manager unit tests', () => {
       };
       const utils = {
         handlers: {
+          CanFulfillIntentHandler: 'CanFulfillIntentHandler',
           EventHandler: 'EventHandler',
           LaunchHandler: 'LaunchHandler',
           IntentHandler: 'IntentHandler',
@@ -48,6 +49,7 @@ describe('alexa manager unit tests', () => {
       expect(utils.builder.custom.callCount).to.eql(1);
       expect(addRequestHandlers.args).to.eql([
         [
+          utils.handlers.CanFulfillIntentHandler,
           utils.handlers.EventHandler,
           utils.handlers.LaunchHandler,
           utils.handlers.IntentHandler,
@@ -96,6 +98,7 @@ describe('alexa manager unit tests', () => {
       };
       const utils = {
         handlers: {
+          CanFulfillIntentHandler: 'CanFulfillIntentHandler',
           EventHandler: 'EventHandler',
           LaunchHandler: 'LaunchHandler',
           IntentHandler: 'IntentHandler',
@@ -123,6 +126,7 @@ describe('alexa manager unit tests', () => {
       expect(utils.builder.custom.callCount).to.eql(1);
       expect(addRequestHandlers.args).to.eql([
         [
+          utils.handlers.CanFulfillIntentHandler,
           utils.handlers.EventHandler,
           utils.handlers.LaunchHandler,
           utils.handlers.IntentHandler,
@@ -165,6 +169,7 @@ describe('alexa manager unit tests', () => {
       };
       const utils = {
         handlers: {
+          CanFulfillIntentHandler: 'CanFulfillIntentHandler',
           EventHandler: 'EventHandler',
           LaunchHandler: 'LaunchHandler',
           IntentHandler: 'IntentHandler',
@@ -192,6 +197,7 @@ describe('alexa manager unit tests', () => {
       expect(utils.builder.custom.callCount).to.eql(1);
       expect(addRequestHandlers.args).to.eql([
         [
+          utils.handlers.CanFulfillIntentHandler,
           utils.handlers.EventHandler,
           utils.handlers.LaunchHandler,
           utils.handlers.IntentHandler,
@@ -234,6 +240,7 @@ describe('alexa manager unit tests', () => {
       };
       const utils = {
         handlers: {
+          CanFulfillIntentHandler: 'CanFulfillIntentHandler',
           EventHandler: 'EventHandler',
           LaunchHandler: 'LaunchHandler',
           IntentHandler: 'IntentHandler',
@@ -261,6 +268,7 @@ describe('alexa manager unit tests', () => {
       expect(utils.builder.custom.callCount).to.eql(1);
       expect(addRequestHandlers.args).to.eql([
         [
+          utils.handlers.CanFulfillIntentHandler,
           utils.handlers.EventHandler,
           utils.handlers.LaunchHandler,
           utils.handlers.IntentHandler,

--- a/tests/lib/services/alexa/request/canFulfill.unit.ts
+++ b/tests/lib/services/alexa/request/canFulfill.unit.ts
@@ -33,25 +33,23 @@ describe('CanFulfillIntentHandler unit tests', () => {
 
     it('can fulfill', async () => {
       const version = {
-        prototype: {
-          model: {
-            intents: [
-              {
-                name: 'name',
-                slots: [
-                  {
-                    id: '1',
-                  },
-                ],
-              },
-            ],
-            slots: [
-              {
-                key: '1',
-                name: 'slot1',
-              },
-            ],
-          },
+        platformData: {
+          intents: [
+            {
+              name: 'name',
+              slots: [
+                {
+                  id: '1',
+                },
+              ],
+            },
+          ],
+          slots: [
+            {
+              key: '1',
+              name: 'slot1',
+            },
+          ],
         },
       };
 
@@ -83,11 +81,9 @@ describe('CanFulfillIntentHandler unit tests', () => {
 
     it('cannot fulfill', async () => {
       const version = {
-        prototype: {
-          model: {
-            intents: [],
-            slots: [],
-          },
+        platformData: {
+          intents: [],
+          slots: [],
         },
       };
 

--- a/tests/lib/services/alexa/request/canFulfill.unit.ts
+++ b/tests/lib/services/alexa/request/canFulfill.unit.ts
@@ -1,0 +1,114 @@
+import { expect } from 'chai';
+import sinon from 'sinon';
+
+import CanFulfillIntentHandler, { Request } from '@/lib/services/alexa/request/canFulfill';
+
+describe('CanFulfillIntentHandler unit tests', () => {
+  describe('canHandle', () => {
+    it('false', () => {
+      expect(CanFulfillIntentHandler.canHandle({ requestEnvelope: { request: { type: 'random' } } } as any)).to.eql(false);
+    });
+
+    it('true', () => {
+      expect(CanFulfillIntentHandler.canHandle({ requestEnvelope: { request: { type: Request.CAN_FULFILL_INTENT } } } as any)).to.eql(true);
+    });
+  });
+
+  describe('handle', () => {
+    const getInput = (request: any, version: any) => ({
+      requestEnvelope: {
+        request,
+      },
+      responseBuilder: {
+        withCanFulfillIntent: sinon.stub().returns({
+          getResponse: sinon.stub(),
+        }),
+      },
+      context: {
+        api: {
+          getVersion: sinon.stub().resolves(version),
+        },
+      },
+    });
+
+    it('can fulfill', async () => {
+      const version = {
+        prototype: {
+          model: {
+            intents: [
+              {
+                name: 'name',
+              },
+            ],
+            slots: [
+              {
+                name: 'slot1',
+              },
+            ],
+          },
+        },
+      };
+
+      const request = {
+        intent: {
+          name: 'name',
+          slots: {
+            slot1: {},
+          },
+        },
+      };
+
+      const input = getInput(request, version);
+
+      const expectedResponse = {
+        canFulfill: 'YES',
+        slots: {
+          slot1: {
+            canUnderstand: 'YES',
+            canFulfill: 'YES',
+          },
+        },
+      };
+
+      await CanFulfillIntentHandler.handle(input as any);
+
+      expect(input.responseBuilder.withCanFulfillIntent.args[0]).to.eql([expectedResponse]);
+    });
+
+    it('cannot fulfill', async () => {
+      const version = {
+        prototype: {
+          model: {
+            intents: [],
+            slots: [],
+          },
+        },
+      };
+
+      const request = {
+        intent: {
+          name: 'name',
+          slots: {
+            slot1: {},
+          },
+        },
+      };
+
+      const input = getInput(request, version);
+
+      const expectedResponse = {
+        canFulfill: 'NO',
+        slots: {
+          slot1: {
+            canUnderstand: 'NO',
+            canFulfill: 'NO',
+          },
+        },
+      };
+
+      await CanFulfillIntentHandler.handle(input as any);
+
+      expect(input.responseBuilder.withCanFulfillIntent.args[0]).to.eql([expectedResponse]);
+    });
+  });
+});

--- a/tests/lib/services/alexa/request/canFulfill.unit.ts
+++ b/tests/lib/services/alexa/request/canFulfill.unit.ts
@@ -38,10 +38,16 @@ describe('CanFulfillIntentHandler unit tests', () => {
             intents: [
               {
                 name: 'name',
+                slots: [
+                  {
+                    id: '1',
+                  },
+                ],
               },
             ],
             slots: [
               {
+                key: '1',
                 name: 'slot1',
               },
             ],

--- a/tests/lib/services/alexa/request/launch.unit.ts
+++ b/tests/lib/services/alexa/request/launch.unit.ts
@@ -11,7 +11,6 @@ describe('launch handler unit tests', () => {
 
     it('true', () => {
       expect(LaunchHandler.canHandle({ requestEnvelope: { request: { type: Request.LAUNCH } } } as any)).to.eql(true);
-      expect(LaunchHandler.canHandle({ requestEnvelope: { request: { type: Request.CAN_FULFILL_INTENT } } } as any)).to.eql(true);
     });
   });
 


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-2849**

### Brief description. What is this change?

The `CanFulfillIntentRequest` is used to gauge if we can understand the intent and slots before attempting to process them.

We can look up the version and check that we have the intent and slots.

See: https://developer.amazon.com/en-US/docs/alexa/custom-skills/implement-canfulfillintentrequest-for-name-free-interaction.html