### PR TITLE
[Merged by Bors] - fix: refresh system variable (VF-000)

### DIFF
--- a/lib/services/alexa/request/lifecycle/initialize.ts
+++ b/lib/services/alexa/request/lifecycle/initialize.ts
@@ -47,7 +47,6 @@ export const initializeGenerator = (utils: typeof utilsObj) => async (runtime: A
   // set based on input
   storage.set(S.LOCALE, requestEnvelope.request.locale);
   storage.set(S.USER, requestEnvelope.context.System.user.userId);
-  storage.set(S.SUPPORTED_INTERFACES, requestEnvelope.context.System.device?.supportedInterfaces);
 
   // set based on metadata
   storage.set(S.ALEXA_PERMISSIONS, settings.permissions ?? []);
@@ -60,16 +59,6 @@ export const initializeGenerator = (utils: typeof utilsObj) => async (runtime: A
     user_id: storage.get(S.USER),
     sessions: storage.get(S.SESSIONS),
     platform: VoiceflowConstants.PlatformType.ALEXA,
-
-    // hidden system variables (code node only)
-    [V.VOICEFLOW]: {
-      // TODO: implement all exposed voiceflow variables
-      permissions: storage.get(S.ALEXA_PERMISSIONS),
-      capabilities: storage.get(S.SUPPORTED_INTERFACES),
-      viewport: input.requestEnvelope?.context?.Viewport,
-      events: [],
-    },
-    [V.SYSTEM]: input.requestEnvelope.context.System,
   });
 
   // initialize all the global variables, as well as slots as global variables

--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -1,5 +1,4 @@
 import { EventType, State } from '@voiceflow/general-runtime/build/runtime';
-import { VoiceflowConstants } from '@voiceflow/voiceflow-types';
 
 import { S, T, V } from '@/lib/constants';
 import { AlexaRuntimeRequest, RequestType } from '@/lib/services/runtime/types';

--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -25,23 +25,24 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
 
   const runtime = runtimeClient.createRuntime(versionID, rawState, request);
   const { turn, storage, variables } = runtime;
+  const system = requestEnvelope.context?.System;
 
   turn.set(T.HANDLER_INPUT, input);
   runtime.turn.set(T.PREVIOUS_OUTPUT, storage.get(S.OUTPUT));
   storage.set(S.OUTPUT, '');
-  storage.set(S.ACCESS_TOKEN, requestEnvelope.context.System.user.accessToken);
-  storage.set(S.SUPPORTED_INTERFACES, requestEnvelope.context.System.device?.supportedInterfaces);
+  storage.set(S.ACCESS_TOKEN, system?.user?.accessToken);
+  storage.set(S.SUPPORTED_INTERFACES, system?.device?.supportedInterfaces);
 
   // hidden system variables (code node only)
   variables.merge({
     [V.VOICEFLOW]: {
       // TODO: implement all exposed voiceflow variables
       permissions: storage.get(S.ALEXA_PERMISSIONS),
-      capabilities: requestEnvelope.context.System.device?.supportedInterfaces,
+      capabilities: system?.device?.supportedInterfaces,
       viewport: requestEnvelope.context?.Viewport,
       events: [],
     },
-    [V.SYSTEM]: requestEnvelope.context.System,
+    [V.SYSTEM]: system,
     // reset response
     [V.RESPONSE]: null,
   });

--- a/tests/lib/services/alexa/request/lifecycle/initialize.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/initialize.unit.ts
@@ -124,8 +124,6 @@ describe('initialize lifecycle unit tests', async () => {
       storageGet.withArgs(F.SPEAK).returns(lastSpeak);
       const permissions = 'permissions';
       storageGet.withArgs(S.ALEXA_PERMISSIONS).returns(permissions);
-      const capabilities = 'capabilities';
-      storageGet.withArgs(S.SUPPORTED_INTERFACES).returns(capabilities);
 
       runtime.storage.get = storageGet;
 
@@ -137,9 +135,8 @@ describe('initialize lifecycle unit tests', async () => {
       expect(runtime.storage.set.args[0]).to.eql([S.SESSIONS, 1]);
       expect(runtime.storage.set.args[1]).to.eql([S.LOCALE, input.requestEnvelope.request.locale]);
       expect(runtime.storage.set.args[2]).to.eql([S.USER, userId]);
-      expect(runtime.storage.set.args[3]).to.eql([S.SUPPORTED_INTERFACES, input.requestEnvelope.context.System.device?.supportedInterfaces]);
-      expect(runtime.storage.set.args[4]).to.eql([S.ALEXA_PERMISSIONS, metaObj.platformData.settings.permissions]);
-      expect(runtime.storage.set.args[5]).to.eql([S.REPEAT, metaObj.platformData.settings.repeat]);
+      expect(runtime.storage.set.args[3]).to.eql([S.ALEXA_PERMISSIONS, metaObj.platformData.settings.permissions]);
+      expect(runtime.storage.set.args[4]).to.eql([S.REPEAT, metaObj.platformData.settings.repeat]);
       expect(runtime.variables.merge.args[0]).to.eql([
         {
           timestamp: 0,
@@ -147,13 +144,6 @@ describe('initialize lifecycle unit tests', async () => {
           user_id: userId,
           sessions: 1,
           platform: VoiceflowConstants.PlatformType.ALEXA,
-          [V.VOICEFLOW]: {
-            events: [],
-            permissions,
-            capabilities,
-            viewport: input.requestEnvelope.context?.Viewport,
-          },
-          _system: input.requestEnvelope.context.System,
         },
       ]);
       expect(utils.client.Store.initialize.args[0]).to.eql([runtime.variables, metaObj.variables, 0]);
@@ -198,8 +188,7 @@ describe('initialize lifecycle unit tests', async () => {
       delete (input.requestEnvelope.context.System as any).device;
       await fn(runtime as any, input as any);
 
-      expect(runtime.storage.set.args[4]).to.eql([S.REPEAT, BaseVersion.RepeatType.ALL]);
-      expect(runtime.storage.set.args[2]).to.eql([S.SUPPORTED_INTERFACES, undefined]);
+      expect(runtime.storage.set.args[3]).to.eql([S.REPEAT, BaseVersion.RepeatType.ALL]);
       expect(runtime.api.getVersion.args).to.eql([[VERSION_ID]]);
     });
 
@@ -316,7 +305,7 @@ describe('initialize lifecycle unit tests', async () => {
 
           expect(topStorage.delete.args[0]).to.eql([F.CALLED_COMMAND]);
           expect(topStorage.get.args[0]).to.eql([F.SPEAK]);
-          expect(runtime.storage.set.args[5]).to.eql([S.OUTPUT, '']);
+          expect(runtime.storage.set.args[4]).to.eql([S.OUTPUT, '']);
           expect(runtime.trace.addTrace.args).to.eql([[{ type: BaseNode.Utils.TraceType.SPEAK, payload: { message: '', type: 'message' } }]]);
           expect(runtime.api.getVersion.args).to.eql([[VERSION_ID]]);
         });
@@ -334,7 +323,7 @@ describe('initialize lifecycle unit tests', async () => {
 
           expect(topStorage.delete.args[0]).to.eql([F.CALLED_COMMAND]);
           expect(topStorage.get.args[0]).to.eql([F.SPEAK]);
-          expect(runtime.storage.set.args[5]).to.eql([S.OUTPUT, lastSpeak]);
+          expect(runtime.storage.set.args[4]).to.eql([S.OUTPUT, lastSpeak]);
           expect(runtime.trace.addTrace.args).to.eql([[{ type: BaseNode.Utils.TraceType.SPEAK, payload: { message: lastSpeak, type: 'message' } }]]);
           expect(runtime.api.getVersion.args).to.eql([[VERSION_ID]]);
         });


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-000**

### Brief description. What is this change?
Nico informed me that the `input.requestEnvelope.context.System` can actually change with critical information through the runtime of a skill. 
Right now we only initialize it at the very beginning of the session (LaunchRequest) and never change it after. With this, we will bump it every single interaction/turn.