### PR TITLE
[Merged by Bors] - fix: use safe json stringify (VF-3452)

### DIFF
--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -1,5 +1,5 @@
 import { EventType, State } from '@voiceflow/general-runtime/build/runtime';
-import safeJSONStringify from 'safe-json-stringify';
+import safeJSONStringify from 'json-stringify-safe';
 
 import { S, T, V } from '@/lib/constants';
 import { AlexaRuntimeRequest, RequestType } from '@/lib/services/runtime/types';

--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -1,4 +1,5 @@
 import { EventType, State } from '@voiceflow/general-runtime/build/runtime';
+import safeJSONStringify from 'safe-json-stringify';
 
 import { S, T, V } from '@/lib/constants';
 import { AlexaRuntimeRequest, RequestType } from '@/lib/services/runtime/types';
@@ -31,9 +32,11 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
 
   runtime.variables.set(V.RESPONSE, null);
 
-  runtime.setEvent(EventType.stateDidCatch, (error) => log.error(`[app] [runtime] stack error caught ${log.vars({ error: JSON.stringify(error) })}`));
+  runtime.setEvent(EventType.stateDidCatch, (error) =>
+    log.error(`[app] [runtime] stack error caught ${log.vars({ error: safeJSONStringify(error) })}`)
+  );
   runtime.setEvent(EventType.handlerDidCatch, (error) =>
-    log.error(`[app] [runtime] handler error caught ${log.vars({ error: JSON.stringify(error) })}`)
+    log.error(`[app] [runtime] handler error caught ${log.vars({ error: safeJSONStringify(error) })}`)
   );
 
   return runtime;

--- a/package.json
+++ b/package.json
@@ -13,6 +13,7 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.26.0",
+    "@types/safe-json-stringify": "^1.1.2",
     "@voiceflow/alexa-types": "2.6.1",
     "@voiceflow/backend-utils": "4.4.0",
     "@voiceflow/base-types": "2.17.0",
@@ -47,6 +48,7 @@
     "pg-format": "^1.0.4",
     "randomstring": "^1.1.5",
     "regenerator-runtime": "^0.13.3",
+    "safe-json-stringify": "^1.2.0",
     "words-to-numbers": "^1.5.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -13,7 +13,6 @@
   },
   "dependencies": {
     "@opentelemetry/api-metrics": "0.26.0",
-    "@types/safe-json-stringify": "^1.1.2",
     "@voiceflow/alexa-types": "2.6.1",
     "@voiceflow/backend-utils": "4.4.0",
     "@voiceflow/base-types": "2.17.0",
@@ -42,13 +41,13 @@
     "express-validator": "^6.3.0",
     "hashids": "^2.2.8",
     "helmet": "^4.6.0",
+    "json-stringify-safe": "^5.0.1",
     "lodash": "^4.17.21",
     "mongodb": "^3.6.3",
     "pg": "^8.5.1",
     "pg-format": "^1.0.4",
     "randomstring": "^1.1.5",
     "regenerator-runtime": "^0.13.3",
-    "safe-json-stringify": "^1.2.0",
     "words-to-numbers": "^1.5.1"
   },
   "devDependencies": {
@@ -65,6 +64,7 @@
     "@types/cors": "^2.8.12",
     "@types/deep-equal-in-any-order": "^1.0.1",
     "@types/express": "^4.17.13",
+    "@types/json-stringify-safe": "^5.0.0",
     "@types/jsonwebtoken": "^8.3.5",
     "@types/lodash": "^4.14.149",
     "@types/mocha": "^5.2.7",

--- a/yarn.lock
+++ b/yarn.lock
@@ -927,6 +927,11 @@
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
 
+"@types/safe-json-stringify@^1.1.2":
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/@types/safe-json-stringify/-/safe-json-stringify-1.1.2.tgz#913796617042de2259f62ce82843c239258ca287"
+  integrity sha512-Hj/LZMBXFH3Qj9sNmNu6syBpkZqBaM00HgP7naf9CnZhB3kdxmrenWUD2cY6vvTWjuBM3NPOLknPKDUOQuTWXA==
+
 "@types/serve-static@*":
   version "1.13.10"
   resolved "https://registry.yarnpkg.com/@types/serve-static/-/serve-static-1.13.10.tgz#f5e0ce8797d2d7cc5ebeda48a52c96c4fa47a8d9"

--- a/yarn.lock
+++ b/yarn.lock
@@ -782,6 +782,11 @@
   resolved "https://registry.yarnpkg.com/@types/json-schema/-/json-schema-7.0.9.tgz#97edc9037ea0c38585320b28964dde3b39e4660d"
   integrity sha512-qcUXuemtEu+E5wZSJHNxUXeCZhAfXKQ41D+duX+VYPde7xyEVZci+/oXKJL13tnRs9lR2pr4fod59GT6/X1/yQ==
 
+"@types/json-stringify-safe@^5.0.0":
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/@types/json-stringify-safe/-/json-stringify-safe-5.0.0.tgz#df34d054419d39323a3730966bacba02ac5e474e"
+  integrity sha512-UUA1sH0RSRROdInuDOA1yoRzbi5xVFD1RHCoOvNRPTNwR8zBkJ/84PZ6NhKVDtKp0FTeIccJCdQz1X2aJPr4uw==
+
 "@types/json5@^0.0.29":
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/@types/json5/-/json5-0.0.29.tgz#ee28707ae94e11d2b827bcbe5270bcea7f3e71ee"
@@ -926,11 +931,6 @@
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/@types/range-parser/-/range-parser-1.2.4.tgz#cd667bcfdd025213aafb7ca5915a932590acdcdc"
   integrity sha512-EEhsLsD6UsDM1yFhAvy0Cjr6VwmpMWqFBCb9w07wVugF7w9nfajxLuVmngTIpgS6svCnm6Vaw+MZhoDCKnOfsw==
-
-"@types/safe-json-stringify@^1.1.2":
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/@types/safe-json-stringify/-/safe-json-stringify-1.1.2.tgz#913796617042de2259f62ce82843c239258ca287"
-  integrity sha512-Hj/LZMBXFH3Qj9sNmNu6syBpkZqBaM00HgP7naf9CnZhB3kdxmrenWUD2cY6vvTWjuBM3NPOLknPKDUOQuTWXA==
 
 "@types/serve-static@*":
   version "1.13.10"


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements VF-3452**

### Brief description. What is this change?

<!-- Build up some context for your teammates on the changes made here and potential tradeoffs made and/or highlight any topics for discussion -->
Calling stringify may potentially throw an error. This causes a catch block to also throw in the runtime loop of `general-runtime`, ultimately causing the bug described in VF-3452. Making sure that the calls are noexcept should solve this.

| project | branch              | PR          |
| -- | ------------------- | ----------- |
| general-runtime | daniel/end-bug/VF-3452 | [link](https://github.com/voiceflow/general-runtime/pull/313) |