### PR TITLE
[Merged by Bors] - fix: add hidden context variable (PL-122)

### DIFF
--- a/lib/constants/flags.ts
+++ b/lib/constants/flags.ts
@@ -43,6 +43,7 @@ export enum Frame {
 export enum Variables {
   TIMESTAMP = 'timestamp',
   SYSTEM = '_system',
+  CONTEXT = '_context',
   RESPONSE = '_response',
   VOICEFLOW = 'voiceflow',
 }

--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -1,4 +1,5 @@
 import { Event, RequestType } from '@voiceflow/event-ingestion-service/build/lib/types';
+import { State } from '@voiceflow/general-runtime/build/runtime';
 import { Response } from 'ask-sdk-model';
 import _isObject from 'lodash/isObject';
 import _mapValues from 'lodash/mapValues';
@@ -14,6 +15,15 @@ import { AlexaHandlerInput, Request } from '../../types';
 const utilsObj = {
   responseHandlers,
 };
+
+const removeHiddenVariables = (state: State): State => ({
+  ...state,
+  variables: {
+    ...state.variables,
+    [V.CONTEXT]: undefined,
+    [V.SYSTEM]: undefined,
+  },
+});
 
 export const responseGenerator = (utils: typeof utilsObj) => async (
   runtime: AlexaRuntime,
@@ -43,7 +53,7 @@ export const responseGenerator = (utils: typeof utilsObj) => async (
     await handler(runtime, responseBuilder);
   }
 
-  attributesManager.setPersistentAttributes(runtime.getFinalState());
+  attributesManager.setPersistentAttributes(removeHiddenVariables(runtime.getFinalState()));
 
   const response = responseBuilder.getResponse();
 

--- a/lib/services/alexa/request/lifecycle/runtime.ts
+++ b/lib/services/alexa/request/lifecycle/runtime.ts
@@ -13,7 +13,7 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
 
   const rawState = (await attributesManager.getPersistentAttributes()) as State;
 
-  const alexaRequest = requestEnvelope.request;
+  const { request: alexaRequest, context } = requestEnvelope;
 
   let request: AlexaRuntimeRequest;
 
@@ -25,7 +25,7 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
 
   const runtime = runtimeClient.createRuntime(versionID, rawState, request);
   const { turn, storage, variables } = runtime;
-  const system = requestEnvelope.context?.System;
+  const system = context?.System;
 
   turn.set(T.HANDLER_INPUT, input);
   runtime.turn.set(T.PREVIOUS_OUTPUT, storage.get(S.OUTPUT));
@@ -43,6 +43,7 @@ const buildRuntime = async (input: AlexaHandlerInput) => {
       events: [],
     },
     [V.SYSTEM]: system,
+    [V.CONTEXT]: context,
     // reset response
     [V.RESPONSE]: null,
   });

--- a/tests/lib/services/alexa/request/lifecycle/response.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/response.unit.ts
@@ -15,7 +15,7 @@ describe('response lifecycle unit tests', () => {
 
     const response = responseGenerator(utils);
 
-    const finalState = 'final-state';
+    const finalState = { stack: {}, variables: { foo: 'bar' }, storage: {} };
     const storageGet = sinon.stub().returns('speak');
     const turnGet = sinon.stub();
     turnGet.withArgs(T.REPROMPT).returns(null);
@@ -85,7 +85,18 @@ describe('response lifecycle unit tests', () => {
     expect(input.responseBuilder.withShouldEndSession.args).to.eql([[true]]);
     expect(responseHandler1.args).to.eql([[runtime, input.responseBuilder]]);
     expect(responseHandler2.args).to.eql([[runtime, input.responseBuilder]]);
-    expect(input.attributesManager.setPersistentAttributes.args).to.eql([[finalState]]);
+    expect(input.attributesManager.setPersistentAttributes.args).to.eql([
+      [
+        {
+          ...finalState,
+          variables: {
+            ...finalState.variables,
+            [V.CONTEXT]: undefined,
+            [V.SYSTEM]: undefined,
+          },
+        },
+      ],
+    ]);
   });
 
   it('stack not empty', async () => {

--- a/tests/lib/services/alexa/request/lifecycle/runtime.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/runtime.unit.ts
@@ -56,6 +56,7 @@ describe('runtime lifecycle unit tests', () => {
             events: [],
           },
           [V.SYSTEM]: input.requestEnvelope.context.System,
+          [V.CONTEXT]: input.requestEnvelope.context,
           // reset response
           [V.RESPONSE]: null,
         },


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements PL-122**

### Brief description. What is this change?
So we have this pattern of exposing raw payloads and information from Alexa's request to the user through the use of "hidden" variables that can really only be accessed by the code (Javascript) step.

It is slightly unfortunate that `_context` is a superset of `_system`, but we can't remove `_system` for backwards compatibility's sake. 


