### PR TITLE
fix: stop propagation of errors [bugfix] (CT-000)

### DIFF
--- a/lib/clients/analytics.ts
+++ b/lib/clients/analytics.ts
@@ -109,7 +109,6 @@ export class AnalyticsSystem extends AbstractClient {
     metadata: State;
     timestamp: Date;
   }): Promise<string> {
-    versionID = await this.dataAPI.unhashVersionID(versionID);
     log.trace(`[analytics] track ${log.vars({ versionID })}`);
     switch (event) {
       case Event.TURN: {


### PR DESCRIPTION
we get tens of thousands every day on our alexa runtime service.
<img width="1560" alt="Screen Shot 2022-09-14 at 12 25 57 AM" src="https://user-images.githubusercontent.com/5643574/190059398-4f25af1a-ee4a-4178-8555-34e401fd74e4.png">

This is because we've already removed the `/convert/` endpoint entirely from `server-data-api`
while this error only affects our analytics/logs and not the actual runtime response, its not as bad

But it does make our logs useless and cost a lot of money.