### PR TITLE
fix: properly escape ssml (BUG-331)

### DIFF
--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -1,5 +1,6 @@
 import { Event, RequestType } from '@voiceflow/event-ingestion-service/build/lib/types';
 import { State } from '@voiceflow/general-runtime/build/runtime';
+import { escapeXmlCharacters } from 'ask-sdk';
 import { Response } from 'ask-sdk-model';
 import _isObject from 'lodash/isObject';
 import _mapValues from 'lodash/mapValues';
@@ -14,6 +15,7 @@ import { AlexaHandlerInput, Request } from '../../types';
 
 const utilsObj = {
   responseHandlers,
+  escapeXmlCharacters,
 };
 
 const removeHiddenVariables = (state: State): State => ({
@@ -41,8 +43,10 @@ export const responseGenerator = (utils: typeof utilsObj) => async (
   }
 
   if (!speakNotAllowedRequestTypes.has(request.type)) {
-    responseBuilder.speak(storage.get<string>(S.OUTPUT) ?? '');
-    responseBuilder.reprompt((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? '');
+    responseBuilder.speak(utils.escapeXmlCharacters(storage.get<string>(S.OUTPUT) ?? ''));
+    responseBuilder.reprompt(
+      utils.escapeXmlCharacters((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? '')
+    );
   }
 
   responseBuilder.withShouldEndSession(!!turn.get(T.END));

--- a/lib/services/alexa/request/lifecycle/response.ts
+++ b/lib/services/alexa/request/lifecycle/response.ts
@@ -1,6 +1,5 @@
 import { Event, RequestType } from '@voiceflow/event-ingestion-service/build/lib/types';
 import { State } from '@voiceflow/general-runtime/build/runtime';
-import { escapeXmlCharacters } from 'ask-sdk';
 import { Response } from 'ask-sdk-model';
 import _isObject from 'lodash/isObject';
 import _mapValues from 'lodash/mapValues';
@@ -12,10 +11,11 @@ import log from '@/logger';
 
 import { DirectivesInvalidWithAudioPlayer, speakNotAllowedRequestTypes } from '../../constants';
 import { AlexaHandlerInput, Request } from '../../types';
+import { encodeSSML } from './utils';
 
 const utilsObj = {
   responseHandlers,
-  escapeXmlCharacters,
+  encodeSSML,
 };
 
 const removeHiddenVariables = (state: State): State => ({
@@ -43,10 +43,8 @@ export const responseGenerator = (utils: typeof utilsObj) => async (
   }
 
   if (!speakNotAllowedRequestTypes.has(request.type)) {
-    responseBuilder.speak(utils.escapeXmlCharacters(storage.get<string>(S.OUTPUT) ?? ''));
-    responseBuilder.reprompt(
-      utils.escapeXmlCharacters((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? '')
-    );
+    responseBuilder.speak(utils.encodeSSML(storage.get<string>(S.OUTPUT) ?? ''));
+    responseBuilder.reprompt(utils.encodeSSML((turn.get<string>(T.REPROMPT) || storage.get<string>(S.OUTPUT)) ?? ''));
   }
 
   responseBuilder.withShouldEndSession(!!turn.get(T.END));

--- a/lib/services/alexa/request/lifecycle/utils.ts
+++ b/lib/services/alexa/request/lifecycle/utils.ts
@@ -1,0 +1,28 @@
+import { escapeXmlCharacters } from 'ask-sdk';
+import { create } from 'xmlbuilder2';
+
+const XML_TAG = '<?xml version="1.0"?>';
+const START_TAG = '<start>';
+const END_TAG = '</start>';
+
+// we cant just escape the ssml as a string because the ssml might contain nested nodes inside it
+// (we would convert <empahis level="strong">text</emphasis> to ;ltempahis....)
+// so instead we need to escape the texts inside the ssml nodes
+export const encodeSSML = (ssmlText: string): string => {
+  if (!ssmlText) return ssmlText;
+  const xml = create(`${START_TAG}${ssmlText}${END_TAG}`);
+  const text = xml
+    .each(
+      (node) => ({
+        ...node,
+        node: {
+          ...node.node,
+          textContent: escapeXmlCharacters(node.node.textContent ?? ''),
+        },
+      }),
+      true,
+      true
+    )
+    .toString();
+  return text.slice(`${XML_TAG}${START_TAG}`.length, -END_TAG.length);
+};

--- a/package.json
+++ b/package.json
@@ -132,7 +132,7 @@
     "clean": "rimraf build",
     "commit": "cz",
     "connect:cli": "vfcli mesh connect alexa-runtime -c \"/bin/bash\"",
-    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register -- start.ts",
+    "dev": "ts-node-dev --files --respawn --exit-child --transpile-only -r tsconfig-paths/register --inspect -- start.ts",
     "e2e": "yarn kill:e2e && NODE_TLS_REJECT_UNAUTHORIZED=0 NODE_ENV=e2e ts-node --files -r tsconfig-paths/register start.ts",
     "e2e:check-deps": "npx wait-on https://localhost:8011/health",
     "e2e:check-deps-ci": "npx wait-on https://server-data-api.test.e2e:8011/health",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "pg-format": "^1.0.4",
     "randomstring": "^1.1.5",
     "regenerator-runtime": "^0.13.3",
-    "words-to-numbers": "^1.5.1"
+    "words-to-numbers": "^1.5.1",
+    "xmlbuilder2": "3.0.2"
   },
   "devDependencies": {
     "@commitlint/cli": "^11.0.0",

--- a/tests/lib/services/alexa/request/lifecycle/response.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/response.unit.ts
@@ -13,7 +13,7 @@ describe('response lifecycle unit tests', () => {
 
     const utils = {
       responseHandlers: [responseHandler1, responseHandler2],
-      escapeXmlCharacters: (input: string): string => input,
+      encodeSSML: (input: string): string => input,
     };
 
     const response = responseGenerator(utils);
@@ -103,7 +103,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('stack not empty', async () => {
-    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
+    const utils = { responseHandlers: [], encodeSSML: (input: string): string => input };
 
     const response = responseGenerator(utils);
     const versionID = 'version.id';
@@ -168,7 +168,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('response variable', async () => {
-    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
+    const utils = { responseHandlers: [], encodeSSML: (input: string): string => input };
 
     const response = responseGenerator(utils);
 
@@ -205,7 +205,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('skips speak if audioplayer event', async () => {
-    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
+    const utils = { responseHandlers: [], encodeSSML: (input: string): string => input };
 
     const response = responseGenerator(utils);
 

--- a/tests/lib/services/alexa/request/lifecycle/response.unit.ts
+++ b/tests/lib/services/alexa/request/lifecycle/response.unit.ts
@@ -11,7 +11,10 @@ describe('response lifecycle unit tests', () => {
     const responseHandler1 = sinon.stub();
     const responseHandler2 = sinon.stub();
 
-    const utils = { responseHandlers: [responseHandler1, responseHandler2] };
+    const utils = {
+      responseHandlers: [responseHandler1, responseHandler2],
+      escapeXmlCharacters: (input: string): string => input,
+    };
 
     const response = responseGenerator(utils);
 
@@ -100,7 +103,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('stack not empty', async () => {
-    const utils = { responseHandlers: [] };
+    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
 
     const response = responseGenerator(utils);
     const versionID = 'version.id';
@@ -165,7 +168,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('response variable', async () => {
-    const utils = { responseHandlers: [] };
+    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
 
     const response = responseGenerator(utils);
 
@@ -202,7 +205,7 @@ describe('response lifecycle unit tests', () => {
   });
 
   it('skips speak if audioplayer event', async () => {
-    const utils = { responseHandlers: [] };
+    const utils = { responseHandlers: [], escapeXmlCharacters: (input: string): string => input };
 
     const response = responseGenerator(utils);
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1588,6 +1588,35 @@
     consola "^2.15.0"
     node-fetch "^2.6.1"
 
+"@oozcitak/dom@1.15.10":
+  version "1.15.10"
+  resolved "https://registry.yarnpkg.com/@oozcitak/dom/-/dom-1.15.10.tgz#dca7289f2b292cff2a901ea4fbbcc0a1ab0b05c2"
+  integrity sha512-0JT29/LaxVgRcGKvHmSrUTEvZ8BXvZhGl2LASRUgHqDTC1M5g1pLmVv56IYNyt3bG2CUjDkc67wnyZC14pbQrQ==
+  dependencies:
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/url" "1.0.4"
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/infra@1.0.8":
+  version "1.0.8"
+  resolved "https://registry.yarnpkg.com/@oozcitak/infra/-/infra-1.0.8.tgz#b0b089421f7d0f6878687608301fbaba837a7d17"
+  integrity sha512-JRAUc9VR6IGHOL7OGF+yrvs0LO8SlqGnPAMqyzOuFZPSZSXI7Xf2O9+awQPSMXgIWGtgUf/dA6Hs6X6ySEaWTg==
+  dependencies:
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/url@1.0.4":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@oozcitak/url/-/url-1.0.4.tgz#ca8b1c876319cf5a648dfa1123600a6aa5cda6ba"
+  integrity sha512-kDcD8y+y3FCSOvnBI6HJgl00viO/nGbQoCINmQ0h98OhnGITrWR3bOGfwYCthgcrV8AnTJz8MzslTQbC3SOAmw==
+  dependencies:
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/util" "8.3.8"
+
+"@oozcitak/util@8.3.8":
+  version "8.3.8"
+  resolved "https://registry.yarnpkg.com/@oozcitak/util/-/util-8.3.8.tgz#10f65fe1891fd8cde4957360835e78fd1936bfdd"
+  integrity sha512-T8TbSnGsxo6TDBJx/Sgv/BlVJL3tshxZP7Aq5R1mSnM5OcHY2dQaxLMu2+E8u3gN0MLOzdjurqN4ZRVuzQycOQ==
+
 "@opentelemetry/api-metrics@0.26.0":
   version "0.26.0"
   resolved "https://registry.yarnpkg.com/@opentelemetry/api-metrics/-/api-metrics-0.26.0.tgz#6f98a5467140ab97f23f598b26e0e18ad8ec59f3"
@@ -6450,6 +6479,14 @@ js-yaml@3.13.1:
     argparse "^1.0.7"
     esprima "^4.0.0"
 
+js-yaml@3.14.0:
+  version "3.14.0"
+  resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.0.tgz#a7a34170f26a21bb162424d8adacb4113a69e482"
+  integrity sha512-/4IbIeHcD9VMHFqDR/gQ7EdZdLimOvW2DdcxFjdyyZ9NsbS+ccrXqVWDtab/lRl5AlUqmpBx8EhPaWR+OtY17A==
+  dependencies:
+    argparse "^1.0.7"
+    esprima "^4.0.0"
+
 js-yaml@^3.13.0, js-yaml@^3.13.1, js-yaml@^3.14.0:
   version "3.14.1"
   resolved "https://registry.yarnpkg.com/js-yaml/-/js-yaml-3.14.1.tgz#dae812fdb3825fa306609a8717383c50c36a0537"
@@ -9998,6 +10035,17 @@ xml2js@0.4.19:
   dependencies:
     sax ">=0.6.0"
     xmlbuilder "~9.0.1"
+
+xmlbuilder2@3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/xmlbuilder2/-/xmlbuilder2-3.0.2.tgz#fc499688b35a916f269e7b459c2fa02bb5c0822a"
+  integrity sha512-h4MUawGY21CTdhV4xm3DG9dgsqyhDkZvVJBx88beqX8wJs3VgyGQgAn5VreHuae6unTQxh115aMK5InCVmOIKw==
+  dependencies:
+    "@oozcitak/dom" "1.15.10"
+    "@oozcitak/infra" "1.0.8"
+    "@oozcitak/util" "8.3.8"
+    "@types/node" "*"
+    js-yaml "3.14.0"
 
 xmlbuilder@~9.0.1:
   version "9.0.7"


### PR DESCRIPTION
**Fixes or implements BUG-331**

### Brief description. What is this change?
We were not escaping ssml string, which means that some invalid strings might corrupt the response.
these characters can be seen here (https://cloud.google.com/text-to-speech/docs/ssml)

ask-sdk provides a util fn to escape these so its just a matter of calling it (https://developer.amazon.com/en-US/docs/alexa/alexa-skills-kit-sdk-for-nodejs/utilities.html#ssmlutils)
### Checklist

- [ ] changes have been validated in an ephemeral environment
- [ ] this is a breaking change and should publish a new major version
- [ ] appropriate tests have been written
- [ ] any new env vars have been added to the [notion doc](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb) and infra has been notified
