### PR TITLE
ci(sonar): use latest sonarcloud orb (IN-976)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -43,7 +43,7 @@ defaults:
 
 orbs:
   vfcommon: voiceflow/common@{{ .values.common_orb_version }}
-  sonarcloud: sonarsource/sonarcloud@1.0.2
+  sonarcloud: sonarsource/sonarcloud@2.0.0
 
 jobs:
   test:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->
# **Fixes or implements IN-976**
### Brief description. What is this change?
Use latest sonarcloud orb vesrsion
