### PR TITLE
ci: use master branch for smoke tests (DX-1583)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -142,7 +142,6 @@ workflows:
       - vfcommon/run-smoke-tests:
           context: dev-test
           e2e-env-name: {{ .values.e2e_env_name }}
-          branch-or-commit: ci
           requires:
             # - vfcommon/build-e2e-tests
             - vfcommon/prepare-env


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

**Fixes or implements DX-1583**

### Brief description. What is this change?

Remove the override to use `ci` branch for smoke tests, it will now track `master`

### Checklist

- [ ] Breaking changes have been communicated, including:
    - New required environment variables
    - Renaming of interfaces (API routes, request/response interface, etc)
- [ ] New environment variables have [been deployed](https://www.notion.so/voiceflow/Add-Environment-Variables-be1b0136479f45f1adece7995a7adbfb)
- [ ] Appropriate tests have been written
    - Bug fixes are accompanied by an updated or new test
    - New features are accompanied by a new test