### PR TITLE
[Merged by Bors] - fix: remove integrations service (PL-901)

### DIFF
--- a/.env.e2e
+++ b/.env.e2e
@@ -12,9 +12,6 @@ AWS_REGION='localhost'
 DYNAMO_ENDPOINT="http://localstack.test.e2e:8000"
 SESSIONS_DYNAMO_TABLE='com.getvoiceflow.e2e.sessions'
 
-# local configs
-INTEGRATIONS_HANDLER_ENDPOINT="https://integrations.test.e2e:8009"
-
 # mongo
 MONGO_URI='mongodb://mongodb.test.e2e:27017'
 MONGO_DB='main-test'

--- a/.env.test
+++ b/.env.test
@@ -6,7 +6,6 @@ AWS_REGION='localhost'
 DYNAMO_ENDPOINT="http://localhost:8000"
 SESSIONS_DYNAMO_TABLE='com.getvoiceflow.test.sessions'
 SESSIONS_SOURCE='dynamo'
-INTEGRATIONS_HANDLER_ENDPOINT="http://integrations"
 LOG_LEVEL='warn'
 MIDDLEWARE_VERBOSITY='none'
 

--- a/README.md
+++ b/README.md
@@ -59,8 +59,6 @@ Also add the following file to the local repository:
 > PORT=4000
 > SESSIONS_DYNAMO_TABLE="none"
 >
-> INTEGRATIONS_HANDLER_ENDPOINT="none"
->
 > LOG_LEVEL="debug"
 > MIDDLEWARE_VERBOSITY="short"
 >
@@ -143,7 +141,6 @@ If you want to add your own database or custom methods, feel free to look at the
 
 These environment variables are optional and meant for specific blocks that have microservices that perform external functions. If left undefined the `code`/`API` block will run their requests locally on this server, as long as the project is trusted it is not an issue.
 
-| name                            | example/values          |                                                                                            desc | required |
-| ------------------------------- | :---------------------- | ----------------------------------------------------------------------------------------------: | -------- |
-| `CODE_HANDLER_ENDPOINT`         | `http://localhost:8804` |                                      stateless cloud service endpoint to execute the code block | NO       |
-| `INTEGRATIONS_HANDLER_ENDPOINT` | `http://localhost:8100` | cloud endpoint for zapier/google blocks - not available if `alexa-runtime` is ran as standalone | NO       |
+| name                    | example/values          |                                                       desc | required |
+| ----------------------- | :---------------------- | ---------------------------------------------------------: | -------- |
+| `CODE_HANDLER_ENDPOINT` | `http://localhost:8804` | stateless cloud service endpoint to execute the code block | NO       |

--- a/config.ts
+++ b/config.ts
@@ -23,7 +23,6 @@ const CONFIG: Config = {
 
   DYNAMO_ENDPOINT: getOptionalProcessEnv('DYNAMO_ENDPOINT'),
   CODE_HANDLER_ENDPOINT: getOptionalProcessEnv('CODE_HANDLER_ENDPOINT'),
-  INTEGRATIONS_HANDLER_ENDPOINT: getRequiredProcessEnv('INTEGRATIONS_HANDLER_ENDPOINT'),
 
   // api-block
   API_MAX_TIMEOUT_MS: Number(getOptionalProcessEnv('API_MAX_TIMEOUT_MS')) || null,

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -28,7 +28,7 @@ import DirectiveHandler, { DirectiveResponseBuilder } from './directive';
 import DisplayHandler, { DisplayResponseBuilder } from './display';
 import DisplayHandlerV2 from './displayV2';
 import GoToHandler from './goTo';
-import IntegrationsHandler from './integrations';
+import IntegrationsStubHandler from './integrations';
 import InteractionHandler from './interaction';
 import PaymentHandler, { PaymentResponseBuilder } from './payment';
 import PermissionCardHandler, { PermissionCardResponseBuilder } from './permissionCard';
@@ -90,6 +90,7 @@ export default ({
     maxResponseBodySizeBytes: API_MAX_CONTENT_LENGTH_BYTES ?? undefined,
     maxRequestBodySizeBytes: API_MAX_BODY_LENGTH_BYTES ?? undefined,
   }),
+  IntegrationsStubHandler(),
   RandomHandler(),
   SetHandler(),
   SetV2Handler(),

--- a/lib/services/runtime/handlers/index.ts
+++ b/lib/services/runtime/handlers/index.ts
@@ -55,7 +55,6 @@ export const responseHandlers = [
 const _v1Handler = _V1Handler();
 
 export default ({
-  INTEGRATIONS_HANDLER_ENDPOINT,
   CODE_HANDLER_ENDPOINT,
   API_MAX_BODY_LENGTH_BYTES,
   API_MAX_CONTENT_LENGTH_BYTES,
@@ -91,7 +90,6 @@ export default ({
     maxResponseBodySizeBytes: API_MAX_CONTENT_LENGTH_BYTES ?? undefined,
     maxRequestBodySizeBytes: API_MAX_BODY_LENGTH_BYTES ?? undefined,
   }),
-  IntegrationsHandler({ integrationsEndpoint: INTEGRATIONS_HANDLER_ENDPOINT }),
   RandomHandler(),
   SetHandler(),
   SetV2Handler(),

--- a/lib/services/runtime/handlers/integrations.ts
+++ b/lib/services/runtime/handlers/integrations.ts
@@ -6,6 +6,8 @@ const VALID_INTEGRATIONS = new Set([
   BaseNode.Utils.IntegrationType.GOOGLE_SHEETS,
 ]);
 
+// the integrations node for zapier and google sheets is no longer supported
+// this is a stub handler to mitigate changes to agent behavior
 const IntegrationsHandler: HandlerFactory<BaseNode.Integration.Node> = () => ({
   canHandle: (node) =>
     node.type === BaseNode.NodeType.INTEGRATIONS && VALID_INTEGRATIONS.has(node.selected_integration),

--- a/lib/services/runtime/handlers/integrations.ts
+++ b/lib/services/runtime/handlers/integrations.ts
@@ -1,38 +1,16 @@
 import { BaseNode } from '@voiceflow/base-types';
-import {
-  HandlerFactory,
-  IntegrationsHandler as GeneralRuntimeIntegrationsHandler,
-} from '@voiceflow/general-runtime/build/runtime';
-
-import log from '@/logger';
-
-export interface IntegrationsOptions {
-  integrationsEndpoint: string;
-}
+import { HandlerFactory } from '@voiceflow/general-runtime/build/runtime';
 
 const VALID_INTEGRATIONS = new Set([
   BaseNode.Utils.IntegrationType.ZAPIER,
   BaseNode.Utils.IntegrationType.GOOGLE_SHEETS,
 ]);
 
-const IntegrationsHandler: HandlerFactory<BaseNode.Integration.Node, IntegrationsOptions> = ({
-  integrationsEndpoint,
-}) => ({
+const IntegrationsHandler: HandlerFactory<BaseNode.Integration.Node> = () => ({
   canHandle: (node) =>
     node.type === BaseNode.NodeType.INTEGRATIONS && VALID_INTEGRATIONS.has(node.selected_integration),
-  handle: (node, runtime, variables, programs) => {
-    if (node.selected_action && node.selected_integration) {
-      log.warn(
-        log.vars({
-          integration: node.selected_integration,
-          action: node.selected_action,
-          versionID: runtime?.getVersionID?.(),
-          projectID: runtime?.project?._id,
-        })
-      );
-    }
-
-    return GeneralRuntimeIntegrationsHandler({ integrationsEndpoint }).handle(node, runtime, variables, programs);
+  handle: (node) => {
+    return node.fail_id ?? node.success_id ?? null;
   },
 });
 

--- a/types.ts
+++ b/types.ts
@@ -20,7 +20,6 @@ export interface Config {
   // Application secrets
   DYNAMO_ENDPOINT: string | null;
   CODE_HANDLER_ENDPOINT: string | null;
-  INTEGRATIONS_HANDLER_ENDPOINT: string;
 
   API_MAX_TIMEOUT_MS: number | null;
   API_MAX_CONTENT_LENGTH_BYTES: number | null;


### PR DESCRIPTION
This fully removes the integrations service. The standard behavior is for a unknown node to get captured by the `NextHandler`:
https://github.com/voiceflow/general-runtime/blob/4e455014623d48d788339953af62c4de2260c367/runtime/lib/Handlers/next.ts#L9-L16

However, this will cause breakage of the agent, as the integration node only has `node.success_id` or `node.fail_id`.

Instead there is now just a stub handler that routes it to the fail port, or whatever port.

To unblock infra, we have to remove `INTEGRATIONS_HANDLER_ENDPOINT` as a required env var.