### PR TITLE
feat: use git shallow clone (IN-1006)

### DIFF
--- a/.circleci/continue_config.yml.tmpl
+++ b/.circleci/continue_config.yml.tmpl
@@ -42,7 +42,7 @@ defaults:
           branch_pattern: master
 
 orbs:
-  vfcommon: voiceflow/common@{{ .values.common_orb_version }}
+  vfcommon: voiceflow/common@dev:7373bc71628ae37637abd6a200605dc889e9fa8c
   sonarcloud: sonarsource/sonarcloud@2.0.0
 
 jobs:


### PR DESCRIPTION
<!-- You can erase any parts of this template not applicable to your Pull Request. -->

### Fixes or implements 
* Linear [IN-1006 ](https://linear.app/voiceflow/issue/IN-1006/use-shallow-clone-instead-of-checkout)

### Brief description. What is this change?
* We can speed up builds by up to and shave off 30 seconds, eg for repos like creator-app 
* Where it takes 30 seconds to clone, it will now take 1 second 
### Implementation details. How do you make this change?
* Do shallow clones for both branches and tags 

### Checklist

- [ ] Tested on creator-app
- [ ] Tested on database-cli 
- [ ] Tested on alexa-runtime
 